### PR TITLE
Add SablierV2OpenEndedStorage contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ time and the time stored in the stream `lastTimeUpdate` (ltu):
 $\ sa = rps \times (now - ltu) \$
 
 _sa_ can be higher than the balance, this explaines the _debt_ I was referring to. The _debt_ is the difference between
-_sa_ and the actual balance - which is **not** stored in the contracts but calculated dynamically in a constant
-function.
+_sa_ and the actual balance - which is **not** stored in the contracts but calculated dynamically in a view function.
 
 #### Withdrawable amount
 

--- a/src/abstracts/SablierV2OpenEndedStorage.sol
+++ b/src/abstracts/SablierV2OpenEndedStorage.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { ISablierV2OpenEndedStorage } from "../interfaces/ISablierV2OpenEndedStorage.sol";
+import { OpenEnded } from "../types/DataTypes.sol";
+import { Errors } from "../libraries/Errors.sol";
+
+/// @title SablierV2OpenEndedStorage
+/// @notice See the documentation in {ISablierV2OpenEndedStorage}.
+abstract contract SablierV2OpenEndedStorage is ISablierV2OpenEndedStorage {
+    /*//////////////////////////////////////////////////////////////////////////
+                                      MODIFIERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Checks that `streamId` does not reference a null stream.
+    modifier notNull(uint256 streamId) {
+        if (!isStream(streamId)) {
+            revert Errors.SablierV2OpenEnded_Null(streamId);
+        }
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                USER-FACING STORAGE
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    uint256 public override nextStreamId;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  PRIVATE STORAGE
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Sablier V2 OpenEnded streams mapped by unsigned integers.
+    mapping(uint256 id => OpenEnded.Stream stream) internal _streams;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    constructor() {
+        nextStreamId = 1;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                 CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getRatePerSecond(uint256 streamId)
+        external
+        view
+        override
+        notNull(streamId)
+        returns (uint128 ratePerSecond)
+    {
+        ratePerSecond = _streams[streamId].ratePerSecond;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getAsset(uint256 streamId) external view override notNull(streamId) returns (IERC20 asset) {
+        asset = _streams[streamId].asset;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getAssetDecimals(uint256 streamId)
+        external
+        view
+        override
+        notNull(streamId)
+        returns (uint8 assetDecimals)
+    {
+        assetDecimals = _streams[streamId].assetDecimals;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getBalance(uint256 streamId) external view override notNull(streamId) returns (uint128 balance) {
+        balance = _streams[streamId].balance;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getLastTimeUpdate(uint256 streamId)
+        external
+        view
+        override
+        notNull(streamId)
+        returns (uint40 lastTimeUpdate)
+    {
+        lastTimeUpdate = _streams[streamId].lastTimeUpdate;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getRecipient(uint256 streamId) external view override notNull(streamId) returns (address recipient) {
+        recipient = _streams[streamId].recipient;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getSender(uint256 streamId) external view notNull(streamId) returns (address sender) {
+        sender = _streams[streamId].sender;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function getStream(uint256 streamId) external view notNull(streamId) returns (OpenEnded.Stream memory stream) {
+        stream = _streams[streamId];
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function isCanceled(uint256 streamId) public view override notNull(streamId) returns (bool result) {
+        result = _streams[streamId].isCanceled;
+    }
+
+    /// @inheritdoc ISablierV2OpenEndedStorage
+    function isStream(uint256 streamId) public view returns (bool result) {
+        result = _streams[streamId].isStream;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            INTERNAL CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Checks whether `msg.sender` is the stream's sender.
+    /// @param streamId The stream id for the query.
+    function _isCallerStreamSender(uint256 streamId) internal view returns (bool) {
+        return msg.sender == _streams[streamId].sender;
+    }
+}

--- a/src/interfaces/ISablierV2OpenEnded.sol
+++ b/src/interfaces/ISablierV2OpenEnded.sol
@@ -3,9 +3,11 @@ pragma solidity >=0.8.20;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { OpenEnded } from "../types/DataTypes.sol";
+import { ISablierV2OpenEndedStorage } from "./ISablierV2OpenEndedStorage.sol";
 
-interface ISablierV2OpenEnded {
+/// @title ISablierV2OpenEnded
+/// @notice Creates and manages Open Ended streams with linear streaming functions.
+interface ISablierV2OpenEnded is ISablierV2OpenEndedStorage {
     /*//////////////////////////////////////////////////////////////////////////
                                        EVENTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -95,61 +97,6 @@ interface ISablierV2OpenEnded {
     /*//////////////////////////////////////////////////////////////////////////
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
-
-    /// @notice Retrieves the rate per second of the stream, denoted in 18 decimals.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The id of the stream to make the query for.
-    function getRatePerSecond(uint256 streamId) external view returns (uint128 ratePerSecond);
-
-    /// @notice Retrieves the asset of the stream.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The id of the stream to make the query for.
-    function getAsset(uint256 streamId) external view returns (IERC20 asset);
-
-    /// @notice Retrieves the asset decimals of the stream.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The id of the stream to make the query for.
-    function getAssetDecimals(uint256 streamId) external view returns (uint8 assetDecimals);
-
-    /// @notice Retrieves the balance of the stream, i.e. the total deposited amounts subtracted by the total withdrawn
-    /// amounts, denoted in 18 decimals.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The stream id for the query.
-    function getBalance(uint256 streamId) external view returns (uint128 balance);
-
-    /// @notice Retrieves the last time update of the stream, which is a Unix timestamp.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The id of the stream to make the query for.
-    function getLastTimeUpdate(uint256 streamId) external view returns (uint40 lastTimeUpdate);
-
-    /// @notice Retrieves the stream's recipient.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The stream id for the query.
-    function getRecipient(uint256 streamId) external view returns (address recipient);
-
-    /// @notice Retrieves the stream's sender.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The stream id for the query.
-    function getSender(uint256 streamId) external view returns (address sender);
-
-    /// @notice Retrieves the stream entity.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The stream id for the query.
-    function getStream(uint256 streamId) external view returns (OpenEnded.Stream memory stream);
-
-    /// @notice Retrieves a flag indicating whether the stream is canceled.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The stream id for the query.
-    function isCanceled(uint256 streamId) external view returns (bool result);
-
-    /// @notice Retrieves a flag indicating whether the stream exists.
-    /// @dev Does not revert if `streamId` references a null stream.
-    /// @param streamId The stream id for the query.
-    function isStream(uint256 streamId) external view returns (bool result);
-
-    /// @notice Counter for stream ids.
-    /// @return The next stream id.
-    function nextStreamId() external view returns (uint256);
 
     /// @notice Calculates the amount that the sender can refund from stream, denoted in 18 decimals.
     /// @dev Reverts if `streamId` references a canceled stream.

--- a/src/interfaces/ISablierV2OpenEndedStorage.sol
+++ b/src/interfaces/ISablierV2OpenEndedStorage.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { OpenEnded } from "../types/DataTypes.sol";
+
+/// @title ISablierV2OpenEndedStorage
+/// @notice Storage variables and their getters for the {SablierV2OpenEnded} contract.
+interface ISablierV2OpenEndedStorage {
+    /*//////////////////////////////////////////////////////////////////////////
+                                 CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Retrieves the asset of the stream.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The id of the stream to make the query for.
+    function getAsset(uint256 streamId) external view returns (IERC20 asset);
+
+    /// @notice Retrieves the asset decimals of the stream.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The id of the stream to make the query for.
+    function getAssetDecimals(uint256 streamId) external view returns (uint8 assetDecimals);
+
+    /// @notice Retrieves the balance of the stream, i.e. the total deposited amounts subtracted by the total withdrawn
+    /// amounts, denoted in 18 decimals.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream id for the query.
+    function getBalance(uint256 streamId) external view returns (uint128 balance);
+
+    /// @notice Retrieves the last time update of the stream, which is a Unix timestamp.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The id of the stream to make the query for.
+    function getLastTimeUpdate(uint256 streamId) external view returns (uint40 lastTimeUpdate);
+
+    /// @notice Retrieves the rate per second of the stream, denoted in 18 decimals.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The id of the stream to make the query for.
+    function getRatePerSecond(uint256 streamId) external view returns (uint128 ratePerSecond);
+
+    /// @notice Retrieves the stream's recipient.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream id for the query.
+    function getRecipient(uint256 streamId) external view returns (address recipient);
+
+    /// @notice Retrieves the stream's sender.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream id for the query.
+    function getSender(uint256 streamId) external view returns (address sender);
+
+    /// @notice Retrieves the stream entity.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream id for the query.
+    function getStream(uint256 streamId) external view returns (OpenEnded.Stream memory stream);
+
+    /// @notice Retrieves a flag indicating whether the stream is canceled.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream id for the query.
+    function isCanceled(uint256 streamId) external view returns (bool result);
+
+    /// @notice Retrieves a flag indicating whether the stream exists.
+    /// @dev Does not revert if `streamId` references a null stream.
+    /// @param streamId The stream id for the query.
+    function isStream(uint256 streamId) external view returns (bool result);
+
+    /// @notice Counter for stream ids.
+    /// @return The next stream id.
+    function nextStreamId() external view returns (uint256);
+}


### PR DESCRIPTION
The idea behind this PR is to improve readability in the `SablierV2OpenEnded` contract by reducing its number of lines of code.