### PR TITLE
feat: Implement broker fee

### DIFF
--- a/src/abstracts/SablierV2OpenEndedState.sol
+++ b/src/abstracts/SablierV2OpenEndedState.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
 import { ISablierV2OpenEndedState } from "../interfaces/ISablierV2OpenEndedState.sol";
 import { OpenEnded } from "../types/DataTypes.sol";
@@ -13,6 +14,9 @@ abstract contract SablierV2OpenEndedState is ISablierV2OpenEndedState {
     /*//////////////////////////////////////////////////////////////////////////
                                   STATE VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierV2OpenEndedState
+    UD60x18 public constant override MAX_BROKER_FEE = UD60x18.wrap(0.1e18);
 
     /// @inheritdoc ISablierV2OpenEndedState
     uint256 public override nextStreamId;

--- a/src/interfaces/ISablierV2OpenEnded.sol
+++ b/src/interfaces/ISablierV2OpenEnded.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { Broker } from "../types/DataTypes.sol";
 import { ISablierV2OpenEndedState } from "./ISablierV2OpenEndedState.sol";
 
 /// @title ISablierV2OpenEnded
@@ -63,8 +64,15 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     /// @param funder The address which funded the stream.
     /// @param asset The contract address of the ERC-20 asset used for streaming.
     /// @param depositAmount The amount of assets deposited, denoted in 18 decimals.
+    /// @param broker The address of the broker who has helped deposit into the stream, e.g. a front-end website.
+    /// @param brokerFeeAmount The amount of assets paid to the broker as a fee, denoted in 18 decimals.
     event DepositOpenEndedStream(
-        uint256 indexed streamId, address indexed funder, IERC20 indexed asset, uint128 depositAmount
+        uint256 indexed streamId,
+        address indexed funder,
+        IERC20 indexed asset,
+        uint128 depositAmount,
+        address broker,
+        uint128 brokerFeeAmount
     );
 
     /// @notice Emitted when assets are refunded from a open-ended stream.
@@ -227,12 +235,15 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     /// @param asset The contract address of the ERC-20 asset used for streaming.
     /// @param amount The amount deposited in the stream.
     /// @return streamId The ID of the newly created stream.
+    /// @param broker Struct containing (i) the address of the broker assisting in depositing into the stream, and (ii)
+    /// the percentage fee paid to the broker from `amount`, denoted as a fixed-point number. Both can be set to zero.
     function createAndDeposit(
         address recipient,
         address sender,
         uint128 ratePerSecond,
         IERC20 asset,
-        uint128 amount
+        uint128 amount,
+        Broker calldata broker
     )
         external
         returns (uint256 streamId);
@@ -252,12 +263,15 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     /// @param asset The contract address of the ERC-20 asset used for streaming.
     /// @param amounts The amounts deposited in the streams.
     /// @return streamIds The IDs of the newly created streams.
+    /// @param broker Struct containing (i) the address of the broker assisting in depositing into the stream, and (ii)
+    /// the percentage fee paid to the broker from `amounts`, denoted as a fixed-point number. Both can be set to zero.
     function createAndDepositMultiple(
         address[] calldata recipients,
         address[] calldata senders,
         uint128[] calldata ratesPerSecond,
         IERC20 asset,
-        uint128[] calldata amounts
+        uint128[] calldata amounts,
+        Broker calldata broker
     )
         external
         returns (uint256[] memory streamIds);
@@ -295,7 +309,9 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     ///
     /// @param streamId The ID of the stream to deposit on.
     /// @param amount The amount deposited in the stream, denoted in 18 decimals.
-    function deposit(uint256 streamId, uint128 amount) external;
+    /// @param broker Struct containing (i) the address of the broker assisting in depositing into the stream, and (ii)
+    /// the percentage fee paid to the broker from `amount`, denoted as a fixed-point number. Both can be set to zero.
+    function deposit(uint256 streamId, uint128 amount, Broker calldata broker) external;
 
     /// @notice Deposits assets in multiple streams.
     ///
@@ -307,7 +323,14 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     ///
     /// @param streamIds The ids of the streams to deposit on.
     /// @param amounts The amount of assets to be deposited, denoted in 18 decimals.
-    function depositMultiple(uint256[] calldata streamIds, uint128[] calldata amounts) external;
+    /// @param broker Struct containing (i) the address of the broker assisting in depositing into the stream, and (ii)
+    /// the percentage fee paid to the broker from `amounts`, denoted as a fixed-point number. Both can be set to zero.
+    function depositMultiple(
+        uint256[] calldata streamIds,
+        uint128[] calldata amounts,
+        Broker calldata broker
+    )
+        external;
 
     /// @notice Refunds the provided amount of assets from the stream to the sender's address.
     ///
@@ -350,7 +373,15 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     /// @param streamId The ID of the stream to restart.
     /// @param ratePerSecond The amount of assets that is increasing by every second, denoted in 18 decimals.
     /// @param amount The amount deposited in the stream.
-    function restartStreamAndDeposit(uint256 streamId, uint128 ratePerSecond, uint128 amount) external;
+    /// @param broker Struct containing (i) the address of the broker assisting in depositing into the stream, and (ii)
+    /// the percentage fee paid to the broker from `amount`, denoted as a fixed-point number. Both can be set to zero.
+    function restartStreamAndDeposit(
+        uint256 streamId,
+        uint128 ratePerSecond,
+        uint128 amount,
+        Broker calldata broker
+    )
+        external;
 
     /// @notice Withdraws the amount of assets calculated based on time reference, from the stream
     /// to the provided `to` address.

--- a/src/interfaces/ISablierV2OpenEndedState.sol
+++ b/src/interfaces/ISablierV2OpenEndedState.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
 import { OpenEnded } from "../types/DataTypes.sol";
 
@@ -63,6 +64,11 @@ interface ISablierV2OpenEndedState {
     /// @dev Does not revert if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
     function isStream(uint256 streamId) external view returns (bool result);
+
+    /// @notice Retrieves the maximum broker fee that can be charged by the broker, denoted as a fixed-point
+    /// number where 1e18 is 100%.
+    /// @dev This value is hard coded as a constant.
+    function MAX_BROKER_FEE() external view returns (UD60x18);
 
     /// @notice Counter for stream ids.
     /// @return The next stream id.

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
 /// @title Errors
 /// @notice Library with custom erros used across the OpenEnded contract.
@@ -16,6 +17,9 @@ library Errors {
     /*//////////////////////////////////////////////////////////////////////////
                                  SABLIER-V2-OpenEnded
     //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Thrown when the broker fee exceeds the maximum allowed fee.
+    error SablierV2OpenEnded_BrokerFeeTooHigh(UD60x18 brokerFee, UD60x18 maxBrokerFee);
 
     /// @notice Thrown when trying to create multiple streams and the number of senders, recipients and rates per second
     /// does not match.

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -2,8 +2,15 @@
 pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
-// TODO: add Broker
+/// @notice Struct encapsulating the broker parameters passed to the _deposit function. Both can be set to zero.
+/// @param account The address receiving the broker's fee.
+/// @param fee The broker's percentage fee from the total amount, denoted as a fixed-point number where 1e18 is 100%.
+struct Broker {
+    address account;
+    UD60x18 fee;
+}
 
 library OpenEnded {
     /// @notice OpenEnded stream.

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -10,33 +10,19 @@ import { SablierV2OpenEnded } from "src/SablierV2OpenEnded.sol";
 import { ERC20Mock } from "./mocks/ERC20Mock.sol";
 import { ERC20MissingReturn } from "./mocks/ERC20MissingReturn.sol";
 import { Assertions } from "./utils/Assertions.sol";
+import { Constants } from "./utils/Constants.sol";
+import { Defaults } from "./utils/Defaults.sol";
 import { Events } from "./utils/Events.sol";
 import { Modifiers } from "./utils/Modifiers.sol";
+import { Users } from "./utils/Types.sol";
 import { Utils } from "./utils/Utils.sol";
 
-struct Users {
-    address sender;
-    address recipient;
-    address eve;
-}
-
-abstract contract Base_Test is Assertions, Events, Modifiers, Test, Utils {
+abstract contract Base_Test is Assertions, Constants, Events, Modifiers, Test, Utils {
     using SafeCast for uint256;
 
     /*//////////////////////////////////////////////////////////////////////////
-                                     DEFAULTS
+                                     VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
-
-    uint128 public constant RATE_PER_SECOND = 0.001e18; // 86.4 daily
-    uint128 public constant DEPOSIT_AMOUNT = 50_000e18;
-    uint40 internal constant MAY_1_2024 = 1_714_518_000;
-    uint40 public immutable ONE_MONTH = 30 days; // "30/360" convention
-    uint128 public constant ONE_MONTH_STREAMED_AMOUNT = 2592e18; // 86.4 * 30
-    uint128 public constant ONE_MONTH_REFUNDABLE_AMOUNT = DEPOSIT_AMOUNT - ONE_MONTH_STREAMED_AMOUNT;
-    uint128 public constant REFUND_AMOUNT = 10_000e18;
-    uint40 public immutable WARP_ONE_MONTH;
-    uint128 public constant WITHDRAW_AMOUNT = 2500e18;
-    uint40 public immutable WITHDRAW_TIME;
 
     Users internal users;
 
@@ -45,20 +31,9 @@ abstract contract Base_Test is Assertions, Events, Modifiers, Test, Utils {
     //////////////////////////////////////////////////////////////////////////*/
 
     ERC20Mock internal dai = new ERC20Mock("Dai stablecoin", "DAI");
-    ERC20MissingReturn internal usdt = new ERC20MissingReturn("USDT stablecoin", "USDT", 6);
+    Defaults internal defaults;
     SablierV2OpenEnded internal openEnded;
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    CONSTRUCTOR
-    //////////////////////////////////////////////////////////////////////////*/
-
-    constructor() {
-        // Warp to May 1, 2024 at 00:00 GMT to provide a more realistic testing environment.
-        vm.warp({ newTimestamp: MAY_1_2024 });
-
-        WARP_ONE_MONTH = uint40(block.timestamp + ONE_MONTH);
-        WITHDRAW_TIME = uint40(block.timestamp) + 2_500_000;
-    }
+    ERC20MissingReturn internal usdt = new ERC20MissingReturn("USDT stablecoin", "USDT", 6);
 
     /*//////////////////////////////////////////////////////////////////////////
                                   SET-UP FUNCTION
@@ -71,13 +46,22 @@ abstract contract Base_Test is Assertions, Events, Modifiers, Test, Utils {
             openEnded = deployOptimizedOpenEnded();
         }
 
-        users.sender = createUser("sender");
-        users.recipient = createUser("recipient");
+        users.broker = createUser("Broker");
         users.eve = createUser("eve");
+        users.recipient = createUser("recipient");
+        users.sender = createUser("sender");
 
         labelConctracts();
 
+        // Deploy the defaults contract.
+        defaults = new Defaults();
+
+        defaults.setUsers(users);
+
         resetPrank(users.sender);
+
+        // Warp to May 1, 2024 at 00:00 GMT to provide a more realistic testing environment.
+        vm.warp({ newTimestamp: MAY_1_2024 });
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -27,8 +27,8 @@ abstract contract Integration_Test is Base_Test {
         for (uint256 i; i < 2; ++i) {
             defaultRecipients.push(users.recipient);
             defaultSenders.push(users.sender);
-            defaultRatesPerSecond.push(RATE_PER_SECOND);
-            defaultDepositAmounts.push(DEPOSIT_AMOUNT);
+            defaultRatesPerSecond.push(defaults.RATE_PER_SECOND());
+            defaultDepositAmounts.push(defaults.DEPOSIT_AMOUNT());
         }
     }
 
@@ -44,7 +44,7 @@ abstract contract Integration_Test is Base_Test {
         return openEnded.create({
             sender: users.sender,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: asset_
         });
     }
@@ -54,7 +54,7 @@ abstract contract Integration_Test is Base_Test {
     }
 
     function defaultDeposit(uint256 streamId) internal {
-        openEnded.deposit(streamId, DEPOSIT_AMOUNT);
+        openEnded.deposit(streamId, defaults.DEPOSIT_AMOUNT(), defaults.brokerWithoutFee());
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/test/integration/cancel-multiple/cancelMultiple.t.sol
+++ b/test/integration/cancel-multiple/cancelMultiple.t.sol
@@ -9,7 +9,7 @@ contract CancelMultiple_Integration_Concrete_Test is Integration_Test {
     function setUp() public override {
         Integration_Test.setUp();
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
     }
 
     function test_CancelMultiple_ArrayCountZero() external whenNotDelegateCalled {
@@ -72,7 +72,7 @@ contract CancelMultiple_Integration_Concrete_Test is Integration_Test {
         uint256 eveStreamId = openEnded.create({
             sender: users.eve,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai
         });
 
@@ -94,7 +94,7 @@ contract CancelMultiple_Integration_Concrete_Test is Integration_Test {
         defaultStreamIds[0] = openEnded.create({
             sender: users.recipient,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai
         });
 

--- a/test/integration/cancel/cancel.t.sol
+++ b/test/integration/cancel/cancel.t.sol
@@ -12,7 +12,7 @@ contract Cancel_Integration_Test is Integration_Test {
     function setUp() public override {
         Integration_Test.setUp();
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
     }
 
     function test_RevertWhen_DelegateCall() external {
@@ -86,10 +86,10 @@ contract Cancel_Integration_Test is Integration_Test {
         whenNoOverrefund
     {
         // Set the timestamp to 1 month ago to create the stream with the same `lastTimeUpdate` as `defaultStreamId`.
-        vm.warp({ newTimestamp: WARP_ONE_MONTH - ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() - defaults.ONE_MONTH() });
         uint256 streamId = createDefaultStreamWithAsset(IERC20(address(usdt)));
-        openEnded.deposit(streamId, DEPOSIT_AMOUNT);
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        openEnded.deposit(streamId, defaults.DEPOSIT_AMOUNT(), defaults.brokerWithoutFee());
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
 
         test_Cancel(streamId, IERC20(address(usdt)));
     }

--- a/test/integration/constructor.t.sol
+++ b/test/integration/constructor.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
+
+import { SablierV2OpenEnded } from "src/SablierV2OpenEnded.sol";
+import { Integration_Test } from "./Integration.t.sol";
+
+contract Constructor_Integration_Concrete_Test is Integration_Test {
+    function test_Constructor() external {
+        // Construct the contract.
+        SablierV2OpenEnded constructedOpenEnded = new SablierV2OpenEnded();
+
+        // {SablierV2OpenEnded.constant}
+        UD60x18 actualMaxBrokerFee = constructedOpenEnded.MAX_BROKER_FEE();
+        UD60x18 expectedMaxBrokerFee = UD60x18.wrap(0.1e18);
+        assertEq(actualMaxBrokerFee, expectedMaxBrokerFee, "MAX_BROKER_FEE");
+
+        uint256 actualStreamId = constructedOpenEnded.nextStreamId();
+        uint256 expectedStreamId = 1;
+        assertEq(actualStreamId, expectedStreamId, "nextStreamId");
+    }
+}

--- a/test/integration/create-multiple/createMultiple.t.sol
+++ b/test/integration/create-multiple/createMultiple.t.sol
@@ -61,7 +61,7 @@ contract CreateMultiple_Integration_Test is Integration_Test {
             streamId: beforeNextStreamId,
             sender: users.sender,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai,
             lastTimeUpdate: uint40(block.timestamp)
         });
@@ -70,7 +70,7 @@ contract CreateMultiple_Integration_Test is Integration_Test {
             streamId: beforeNextStreamId + 1,
             sender: users.sender,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai,
             lastTimeUpdate: uint40(block.timestamp)
         });
@@ -91,7 +91,7 @@ contract CreateMultiple_Integration_Test is Integration_Test {
         );
 
         OpenEnded.Stream memory expectedStream = OpenEnded.Stream({
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai,
             assetDecimals: 18,
             balance: 0,

--- a/test/integration/create/create.t.sol
+++ b/test/integration/create/create.t.sol
@@ -16,18 +16,20 @@ contract Create_Integration_Test is Integration_Test {
 
     function test_RevertWhen_DelegateCall() external {
         bytes memory callData =
-            abi.encodeCall(ISablierV2OpenEnded.create, (users.sender, users.recipient, RATE_PER_SECOND, dai));
+            abi.encodeCall(ISablierV2OpenEnded.create, (users.sender, users.recipient, defaults.RATE_PER_SECOND(), dai));
         expectRevertDueToDelegateCall(callData);
     }
 
     function test_RevertWhen_SenderZeroAddress() external whenNotDelegateCalled {
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
         vm.expectRevert(Errors.SablierV2OpenEnded_SenderZeroAddress.selector);
-        openEnded.create({ sender: address(0), recipient: users.recipient, ratePerSecond: RATE_PER_SECOND, asset: dai });
+        openEnded.create({ sender: address(0), recipient: users.recipient, ratePerSecond: ratePerSecond, asset: dai });
     }
 
     function test_RevertWhen_RecipientZeroAddress() external whenNotDelegateCalled whenSenderNonZeroAddress {
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
         vm.expectRevert(Errors.SablierV2OpenEnded_RecipientZeroAddress.selector);
-        openEnded.create({ sender: users.sender, recipient: address(0), ratePerSecond: RATE_PER_SECOND, asset: dai });
+        openEnded.create({ sender: users.sender, recipient: address(0), ratePerSecond: ratePerSecond, asset: dai });
     }
 
     function test_RevertWhen_ratePerSecondZero()
@@ -45,16 +47,17 @@ contract Create_Integration_Test is Integration_Test {
         whenNotDelegateCalled
         whenSenderNonZeroAddress
         whenRecipientNonZeroAddress
-        whenratePerSecondNonZero
+        whenRatePerSecondNonZero
     {
         address nonContract = address(8128);
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2OpenEnded_InvalidAssetDecimals.selector, IERC20(nonContract))
         );
         openEnded.create({
             sender: users.sender,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: ratePerSecond,
             asset: IERC20(nonContract)
         });
     }
@@ -64,7 +67,7 @@ contract Create_Integration_Test is Integration_Test {
         whenNotDelegateCalled
         whenSenderNonZeroAddress
         whenRecipientNonZeroAddress
-        whenratePerSecondNonZero
+        whenRatePerSecondNonZero
         whenAssetContract
     {
         uint256 expectedStreamId = openEnded.nextStreamId();
@@ -74,7 +77,7 @@ contract Create_Integration_Test is Integration_Test {
             streamId: expectedStreamId,
             sender: users.sender,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai,
             lastTimeUpdate: uint40(block.timestamp)
         });
@@ -82,13 +85,13 @@ contract Create_Integration_Test is Integration_Test {
         uint256 actualStreamId = openEnded.create({
             sender: users.sender,
             recipient: users.recipient,
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai
         });
 
         OpenEnded.Stream memory actualStream = openEnded.getStream(actualStreamId);
         OpenEnded.Stream memory expectedStream = OpenEnded.Stream({
-            ratePerSecond: RATE_PER_SECOND,
+            ratePerSecond: defaults.RATE_PER_SECOND(),
             asset: dai,
             assetDecimals: 18,
             balance: 0,

--- a/test/integration/deposit/deposit.tree
+++ b/test/integration/deposit/deposit.tree
@@ -9,16 +9,19 @@ deposit.t.sol
       │  └── it should revert
       └── given the id does not reference a canceled stream
          ├── when the deposit amount is zero
-         │  └── it should revert
+         │   └── it should revert
          └── when the deposit amount is not zero
-            ├── when the asset misses the ERC-20 return 
-            │  └── it should make the deposit
-            └── when the asset does not miss the ERC-20 return value
-               ├── given the asset does not have 18 decimals
-               │  ├── it should update the stream balance
-               │  ├── it should perform the ERC-20 transfer
-               │  └── it should emit a {Transfer} and {DepositOpenEndedStream} event
-               └── given the asset has 18 decimals
-                  ├── it should update the stream balance
-                  ├── it should perform the ERC-20 transfer
-                  └── it should emit a {Transfer} and {DepositOpenEndedStream} event
+             ├── when the broker fee is too high
+             │   └── it should revert
+             └── when the broker fee is not too high
+                 ├── when the asset misses the ERC-20 return
+                 │   └── it should make the deposit
+                 └── when the asset does not miss the ERC-20 return value
+                     ├── given the asset does not have 18 decimals
+                     │   ├── it should update the stream balance
+                     │   ├── it should perform the ERC-20 transfers
+                     │   └── it should emit a {Transfer} and {DepositOpenEndedStream} event
+                     └── given the asset has 18 decimals
+                         ├── it should update the stream balance
+                         ├── it should perform the ERC-20 transfers
+                         └── it should emit a {Transfer} and {DepositOpenEndedStream} event

--- a/test/integration/refundable-amount-of/refundableAmountOf.t.sol
+++ b/test/integration/refundable-amount-of/refundableAmountOf.t.sol
@@ -25,9 +25,9 @@ contract RefundableAmountOf_Integration_Test is Integration_Test {
 
     function test_RefundableAmountOf_BalanceLessThanOrEqualStreamedAmount() external givenNotNull givenNotCanceled {
         uint128 depositAmount = 1e18;
-        openEnded.deposit(defaultStreamId, depositAmount);
+        openEnded.deposit(defaultStreamId, depositAmount, defaults.brokerWithoutFee());
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
         uint128 refundableAmount = openEnded.refundableAmountOf(defaultStreamId);
         assertEq(refundableAmount, 0, "refundable amount");
     }
@@ -35,8 +35,8 @@ contract RefundableAmountOf_Integration_Test is Integration_Test {
     function test_RefundableAmountOf() external givenNotNull givenNotCanceled {
         defaultDeposit();
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
         uint128 refundableAmount = openEnded.refundableAmountOf(defaultStreamId);
-        assertEq(refundableAmount, ONE_MONTH_REFUNDABLE_AMOUNT, "refundable amount");
+        assertEq(refundableAmount, defaults.ONE_MONTH_REFUNDABLE_AMOUNT(), "refundable amount");
     }
 }

--- a/test/integration/restart-stream/restartStream.t.sol
+++ b/test/integration/restart-stream/restartStream.t.sol
@@ -14,19 +14,24 @@ contract RestartStream_Integration_Test is Integration_Test {
     }
 
     function test_RevertWhen_DelegateCall() external {
-        bytes memory callData = abi.encodeCall(ISablierV2OpenEnded.restartStream, (defaultStreamId, RATE_PER_SECOND));
+        bytes memory callData =
+            abi.encodeCall(ISablierV2OpenEnded.restartStream, (defaultStreamId, defaults.RATE_PER_SECOND()));
         expectRevertDueToDelegateCall(callData);
     }
 
     function test_RevertGiven_Null() external whenNotDelegateCalled {
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
+
         expectRevertNull();
-        openEnded.restartStream({ streamId: nullStreamId, ratePerSecond: RATE_PER_SECOND });
+        openEnded.restartStream({ streamId: nullStreamId, ratePerSecond: ratePerSecond });
     }
 
     function test_RevertGiven_NotCanceled() external whenNotDelegateCalled givenNotNull {
         uint256 streamId = createDefaultStream();
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
+
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2OpenEnded_StreamNotCanceled.selector, streamId));
-        openEnded.restartStream({ streamId: streamId, ratePerSecond: RATE_PER_SECOND });
+        openEnded.restartStream({ streamId: streamId, ratePerSecond: ratePerSecond });
     }
 
     function test_RevertWhen_CallerUnauthorized_Recipient()
@@ -37,10 +42,12 @@ contract RestartStream_Integration_Test is Integration_Test {
         whenCallerUnauthorized
     {
         resetPrank({ msgSender: users.recipient });
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
+
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2OpenEnded_Unauthorized.selector, defaultStreamId, users.recipient)
         );
-        openEnded.restartStream({ streamId: defaultStreamId, ratePerSecond: RATE_PER_SECOND });
+        openEnded.restartStream({ streamId: defaultStreamId, ratePerSecond: ratePerSecond });
     }
 
     function test_RevertWhen_CallerUnauthorized_MaliciousThirdParty()
@@ -51,10 +58,12 @@ contract RestartStream_Integration_Test is Integration_Test {
         whenCallerUnauthorized
     {
         resetPrank({ msgSender: users.eve });
+        uint128 ratePerSecond = defaults.RATE_PER_SECOND();
+
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2OpenEnded_Unauthorized.selector, defaultStreamId, users.eve)
         );
-        openEnded.restartStream({ streamId: defaultStreamId, ratePerSecond: RATE_PER_SECOND });
+        openEnded.restartStream({ streamId: defaultStreamId, ratePerSecond: ratePerSecond });
     }
 
     function test_RevertWhen_ratePerSecondZero()
@@ -74,15 +83,15 @@ contract RestartStream_Integration_Test is Integration_Test {
         givenNotNull
         givenCanceled
         whenCallerAuthorized
-        whenratePerSecondNonZero
+        whenRatePerSecondNonZero
     {
-        openEnded.restartStream({ streamId: defaultStreamId, ratePerSecond: RATE_PER_SECOND });
+        openEnded.restartStream({ streamId: defaultStreamId, ratePerSecond: defaults.RATE_PER_SECOND() });
 
         bool isCanceled = openEnded.isCanceled(defaultStreamId);
         assertFalse(isCanceled);
 
         uint128 actualratePerSecond = openEnded.getRatePerSecond(defaultStreamId);
-        assertEq(actualratePerSecond, RATE_PER_SECOND, "ratePerSecond");
+        assertEq(actualratePerSecond, defaults.RATE_PER_SECOND(), "ratePerSecond");
 
         uint40 actualLastTimeUpdate = openEnded.getLastTimeUpdate(defaultStreamId);
         assertEq(actualLastTimeUpdate, block.timestamp, "lastTimeUpdate");

--- a/test/integration/stream-debt-of/streamDebtOf.t.sol
+++ b/test/integration/stream-debt-of/streamDebtOf.t.sol
@@ -26,9 +26,9 @@ contract StreamDebtOf_Integration_Test is Integration_Test {
     }
 
     function test_streamDebtOf() external givenNotNull givenNotCanceled {
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
         uint128 streamDebt = openEnded.streamDebtOf(defaultStreamId);
 
-        assertEq(streamDebt, ONE_MONTH_STREAMED_AMOUNT, "stream debt");
+        assertEq(streamDebt, defaults.ONE_MONTH_STREAMED_AMOUNT(), "stream debt");
     }
 }

--- a/test/integration/streamed-amount-of/streamedAmountOf.t.sol
+++ b/test/integration/streamed-amount-of/streamedAmountOf.t.sol
@@ -24,8 +24,8 @@ contract StreamedAmountOf_Integration_Test is Integration_Test {
     }
 
     function test_StreamedAmountOf() external givenNotNull givenNotCanceled {
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
         uint128 streamedAmount = openEnded.streamedAmountOf(defaultStreamId);
-        assertEq(streamedAmount, ONE_MONTH_STREAMED_AMOUNT, "streamed amount");
+        assertEq(streamedAmount, defaults.ONE_MONTH_STREAMED_AMOUNT(), "streamed amount");
     }
 }

--- a/test/integration/withdraw-multiple/withdrawAtMultiple.t.sol
+++ b/test/integration/withdraw-multiple/withdrawAtMultiple.t.sol
@@ -12,9 +12,9 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
     function setUp() public override {
         Integration_Test.setUp();
 
-        times.push(WITHDRAW_TIME);
-        times.push(WITHDRAW_TIME);
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        times.push(defaults.WITHDRAW_TIME());
+        times.push(defaults.WITHDRAW_TIME());
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
     }
 
     function test_RevertWhen_DelegateCall() external {
@@ -149,7 +149,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierV2OpenEnded_WithdrawalTimeInTheFuture.selector, futureTime, WARP_ONE_MONTH
+                Errors.SablierV2OpenEnded_WithdrawalTimeInTheFuture.selector, futureTime, defaults.WARP_ONE_MONTH()
             )
         );
         openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
@@ -171,7 +171,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierV2OpenEnded_WithdrawalTimeInTheFuture.selector, futureTime, WARP_ONE_MONTH
+                Errors.SablierV2OpenEnded_WithdrawalTimeInTheFuture.selector, futureTime, defaults.WARP_ONE_MONTH()
             )
         );
         openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
@@ -237,27 +237,27 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
             streamId: defaultStreamIds[0],
             to: users.recipient,
             asset: dai,
-            withdrawAmount: WITHDRAW_AMOUNT
+            withdrawAmount: defaults.WITHDRAW_AMOUNT()
         });
         vm.expectEmit({ emitter: address(openEnded) });
         emit WithdrawFromOpenEndedStream({
             streamId: defaultStreamIds[1],
             to: users.recipient,
             asset: dai,
-            withdrawAmount: WITHDRAW_AMOUNT
+            withdrawAmount: defaults.WITHDRAW_AMOUNT()
         });
 
         openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
 
         actualLastTimeUpdate = openEnded.getLastTimeUpdate(defaultStreamIds[0]);
-        expectedLastTimeUpdate = WITHDRAW_TIME;
+        expectedLastTimeUpdate = defaults.WITHDRAW_TIME();
         assertEq(actualLastTimeUpdate, expectedLastTimeUpdate, "last time updated");
 
         actualLastTimeUpdate = openEnded.getLastTimeUpdate(defaultStreamIds[1]);
         assertEq(actualLastTimeUpdate, expectedLastTimeUpdate, "last time updated");
 
         uint128 actualStreamBalance = openEnded.getBalance(defaultStreamIds[0]);
-        uint128 expectedStreamBalance = DEPOSIT_AMOUNT - WITHDRAW_AMOUNT;
+        uint128 expectedStreamBalance = defaults.DEPOSIT_AMOUNT() - defaults.WITHDRAW_AMOUNT();
         assertEq(actualStreamBalance, expectedStreamBalance, "stream balance");
 
         actualStreamBalance = openEnded.getBalance(defaultStreamIds[1]);

--- a/test/integration/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/integration/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -25,9 +25,9 @@ contract WithdrawableAmountOf_Integration_Test is Integration_Test {
 
     function test_WithdrawableAmountOf_BalanceLessThanOrEqualStreamedAmount() external givenNotNull givenNotCanceled {
         uint128 depositAmount = 1e18;
-        openEnded.deposit(defaultStreamId, depositAmount);
+        openEnded.deposit(defaultStreamId, depositAmount, defaults.brokerWithoutFee());
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
         uint128 withdrawableAmount = openEnded.withdrawableAmountOf(defaultStreamId);
         assertEq(withdrawableAmount, depositAmount, "withdrawable amount");
     }
@@ -35,8 +35,8 @@ contract WithdrawableAmountOf_Integration_Test is Integration_Test {
     function test_WithdrawableAmountOf() external givenNotNull givenNotCanceled {
         defaultDeposit();
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: defaults.WARP_ONE_MONTH() });
         uint128 withdrawableAmount = openEnded.withdrawableAmountOf(defaultStreamId);
-        assertEq(withdrawableAmount, ONE_MONTH_STREAMED_AMOUNT, "withdrawable amount");
+        assertEq(withdrawableAmount, defaults.ONE_MONTH_STREAMED_AMOUNT(), "withdrawable amount");
     }
 }

--- a/test/invariant/handlers/BaseHandler.sol
+++ b/test/invariant/handlers/BaseHandler.sol
@@ -4,11 +4,12 @@ pragma solidity >=0.8.22 <0.9.0;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { StdCheats } from "forge-std/src/StdCheats.sol";
 
+import { Constants } from "../../utils/Constants.sol";
 import { Utils } from "../../utils/Utils.sol";
 import { TimestampStore } from "../stores/TimestampStore.sol";
 
 /// @notice Base contract with common logic needed by all handler contracts.
-abstract contract BaseHandler is StdCheats, Utils {
+abstract contract BaseHandler is Constants, StdCheats, Utils {
     /*//////////////////////////////////////////////////////////////////////////
                                      CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -60,14 +61,14 @@ abstract contract BaseHandler is StdCheats, Utils {
     }
 
     /// @dev Checks user assumptions.
-    modifier checkUsers(address sender, address recipient) {
-        // The protocol doesn't allow the sender or recipient to be the zero address.
-        if (sender == address(0) || recipient == address(0)) {
+    modifier checkUsers(address sender, address recipient, address broker) {
+        // The protocol doesn't allow the sender, recipient or broker to be the zero address.
+        if (sender == address(0) || recipient == address(0) || broker == address(0)) {
             return;
         }
 
         // Prevent the contract itself from playing the role of any user.
-        if (sender == address(this) || recipient == address(this)) {
+        if (sender == address(this) || recipient == address(this) || broker == address(this)) {
             return;
         }
 

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { StdAssertions } from "forge-std/src/StdAssertions.sol";
-
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { PRBMathAssertions } from "@prb/math/test/utils/Assertions.sol";
 import { OpenEnded } from "src/types/DataTypes.sol";
 
-abstract contract Assertions is StdAssertions {
+abstract contract Assertions is PRBMathAssertions {
     /*//////////////////////////////////////////////////////////////////////////
                                      ASSERTIONS
     //////////////////////////////////////////////////////////////////////////*/

--- a/test/utils/Constants.sol
+++ b/test/utils/Constants.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.22;
+
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
+
+abstract contract Constants {
+    UD60x18 internal constant MAX_BROKER_FEE = UD60x18.wrap(0.1e18); // 10%
+    uint40 internal constant MAY_1_2024 = 1_714_518_000;
+    uint40 public immutable ONE_MONTH = 30 days; // "30/360" convention
+}

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { ud, UD60x18 } from "@prb/math/src/UD60x18.sol";
+
+import { Broker } from "../../src/types/DataTypes.sol";
+
+import { Constants } from "./Constants.sol";
+import { Users } from "./Types.sol";
+
+/// @notice Contract with default values used throughout the tests.
+contract Defaults is Constants {
+    /*//////////////////////////////////////////////////////////////////////////
+                                  STATE VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    UD60x18 public constant BROKER_FEE = UD60x18.wrap(0.005e18); // 0.5%
+    uint128 public constant BROKER_FEE_AMOUNT = 251.256281407035175879e18; // 0.5% of total amount
+    uint128 public constant DEPOSIT_AMOUNT = 50_000e18;
+    uint128 public constant DEPOSIT_AMOUNT_WITH_FEE = 50_251.256281407035175879e18; // deposit + broker fee
+    uint128 public constant ONE_MONTH_STREAMED_AMOUNT = 2592e18; // 86.4 * 30
+    uint128 public constant ONE_MONTH_REFUNDABLE_AMOUNT = DEPOSIT_AMOUNT - ONE_MONTH_STREAMED_AMOUNT;
+    uint128 public constant RATE_PER_SECOND = 0.001e18; // 86.4 daily
+    uint128 public constant REFUND_AMOUNT = 10_000e18;
+    uint40 public immutable WARP_ONE_MONTH = MAY_1_2024 + ONE_MONTH;
+    uint128 public constant WITHDRAW_AMOUNT = 2500e18;
+    uint40 public immutable WITHDRAW_TIME = MAY_1_2024 + 2_500_000;
+
+    Users internal users;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function setUsers(Users memory users_) public {
+        users = users_;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      STRUCTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function brokerWithFee() public view returns (Broker memory) {
+        return Broker({ account: users.broker, fee: BROKER_FEE });
+    }
+
+    function brokerWithoutFee() public pure returns (Broker memory) {
+        return Broker({ account: address(0), fee: ud(0) });
+    }
+}

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -33,7 +33,12 @@ abstract contract Events {
     );
 
     event DepositOpenEndedStream(
-        uint256 indexed streamId, address indexed funder, IERC20 indexed asset, uint128 depositAmount
+        uint256 indexed streamId,
+        address indexed funder,
+        IERC20 indexed asset,
+        uint128 depositAmount,
+        address broker,
+        uint128 brokerFeeAmount
     );
 
     event RefundFromOpenEndedStream(

--- a/test/utils/Modifiers.sol
+++ b/test/utils/Modifiers.sol
@@ -6,7 +6,15 @@ abstract contract Modifiers {
                                        COMMON
     //////////////////////////////////////////////////////////////////////////*/
 
-    modifier whenratePerSecondNonZero() {
+    modifier givenNotCanceled() {
+        _;
+    }
+
+    modifier givenNotNull() {
+        _;
+    }
+
+    modifier whenBrokerFeeNotTooHigh() {
         _;
     }
 
@@ -22,11 +30,7 @@ abstract contract Modifiers {
         _;
     }
 
-    modifier givenNotCanceled() {
-        _;
-    }
-
-    modifier givenNotNull() {
+    modifier whenRatePerSecondNonZero() {
         _;
     }
 
@@ -34,7 +38,7 @@ abstract contract Modifiers {
                               ADJUST-AMOUNT-PER-SECOND
     //////////////////////////////////////////////////////////////////////////*/
 
-    modifier whenratePerSecondNotDifferent() {
+    modifier whenRatePerSecondNotDifferent() {
         _;
     }
 
@@ -50,7 +54,7 @@ abstract contract Modifiers {
                                        CREATE
     //////////////////////////////////////////////////////////////////////////*/
 
-    modifier whenSenderNonZeroAddress() {
+    modifier whenAssetContract() {
         _;
     }
 
@@ -58,7 +62,7 @@ abstract contract Modifiers {
         _;
     }
 
-    modifier whenAssetContract() {
+    modifier whenSenderNonZeroAddress() {
         _;
     }
 
@@ -66,11 +70,11 @@ abstract contract Modifiers {
                                   CREATE-MULTIPLE
     //////////////////////////////////////////////////////////////////////////*/
 
-    modifier whenArrayCountsNotEqual() {
+    modifier whenArrayCountsEqual() {
         _;
     }
 
-    modifier whenArrayCountsEqual() {
+    modifier whenArrayCountsNotEqual() {
         _;
     }
 

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.22;
+
+struct Users {
+    // Default stream broker.
+    address payable broker;
+    // Malicious user.
+    address payable eve;
+    // Default stream recipient.
+    address payable recipient;
+    // Default stream sender.
+    address payable sender;
+}

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -2,10 +2,10 @@
 pragma solidity >=0.8.22;
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { PRBMathUtils } from "@prb/math/test/utils/Utils.sol";
 import { CommonBase } from "forge-std/src/Base.sol";
-import { StdUtils } from "forge-std/src/StdUtils.sol";
 
-abstract contract Utils is CommonBase, StdUtils {
+abstract contract Utils is CommonBase, PRBMathUtils {
     /// @dev Checks if the Foundry profile is "test-optimized".
     function isTestOptimizedProfile() internal view returns (bool) {
         string memory profile = vm.envOr({ name: "FOUNDRY_PROFILE", defaultValue: string("default") });


### PR DESCRIPTION
Resolves #11 

Summary
-----
This PR implements broker fees. Any third party that helps users make deposits through them can charge service fee by providing broker parameter during deposit calls.

### New features
- Implements broker fee: `createAndDeposit `, `deposit`, `depositMultiple` and `restartStreamAndDeposit` now includes an additional `OpenEnded.Broker calldata broker` parameter.
```solidity
struct Broker {
    address account;
    uint128 fee;
}
```
- function [_deposit](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/src/SablierV2OpenEnded.sol#L523C1-L563C6) handles broker.
- Added `MAX_FEE` as public constant in [SablierV2OpenEndedStorage.sol](https://github.com/sablier-labs/v2-open-ended/blob/feat/implement-broker-fee/src/abstracts/SablierV2OpenEndedStorage.sol#L30). It has been set to 1000 which represents 10%. 

### Tests
- Added default broker view functions in [Base.t.sol](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/Base.t.sol#L125C1-L135C6)
- In all test functions, deposit takes in `defaultBroker` parameter (broker fee = 0)
- Updated test cases in [deposit.t.sol](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/integration/deposit/deposit.t.sol#L85C1-L103C1)
- updated [deposit.tree](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/integration/deposit/deposit.tree)
- Renamed instrument label from from `createAndDeposit` to `create` in [OpenEndedCreateHandler.sol file](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/invariant/handlers/OpenEndedCreateHandler.sol#L51) and `restartStream` to`restartStreamAndDeposit` in [OpenEndedHandler.sol](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/invariant/handlers/OpenEndedHandler.sol#L209)
- Handled broker fee in [restartStreamAndDeposit](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/invariant/handlers/OpenEndedHandler.sol#L201C1-L241C1) and [deposit](https://github.com/sablier-labs/v2-open-ended/blob/7538814a63f72bfb99d2ae1bfacf0ada3a1be399/test/invariant/handlers/OpenEndedHandler.sol#L106C1-L144C6)
- Increased invariant runs to 256 from 20. 20 wasn't enough to detect failed cases.