### PR TITLE
Remove isCanceled and isStream from Stream struct

### DIFF
--- a/src/SablierV2OpenEnded.sol
+++ b/src/SablierV2OpenEnded.sol
@@ -408,9 +408,6 @@ contract SablierV2OpenEnded is ISablierV2OpenEnded, NoDelegateCall, SablierV2Ope
         // condition is checked to avoid exploits in case of a bug.
         _checkCalculatedAmount(streamId, sum);
 
-        // Effects: set the stream as canceled.
-        _streams[streamId].isCanceled = true;
-
         // Effects: set the rate per second to zero.
         _streams[streamId].ratePerSecond = 0;
 
@@ -471,8 +468,6 @@ contract SablierV2OpenEnded is ISablierV2OpenEnded, NoDelegateCall, SablierV2Ope
             asset: asset,
             assetDecimals: assetDecimals,
             balance: 0,
-            isCanceled: false,
-            isStream: true,
             lastTimeUpdate: uint40(block.timestamp),
             ratePerSecond: ratePerSecond,
             recipient: recipient,
@@ -559,7 +554,7 @@ contract SablierV2OpenEnded is ISablierV2OpenEnded, NoDelegateCall, SablierV2Ope
         onlySender(streamId)
     {
         // Checks: the stream is canceled.
-        if (!_streams[streamId].isCanceled) {
+        if (!isCanceled(streamId)) {
             revert Errors.SablierV2OpenEnded_StreamNotCanceled(streamId);
         }
 
@@ -570,9 +565,6 @@ contract SablierV2OpenEnded is ISablierV2OpenEnded, NoDelegateCall, SablierV2Ope
 
         // Effects: set the rate per second.
         _streams[streamId].ratePerSecond = ratePerSecond;
-
-        // Effects: set the stream as not canceled.
-        _streams[streamId].isCanceled = false;
 
         // Effects: update the stream time.
         _updateTime(streamId, uint40(block.timestamp));

--- a/src/abstracts/SablierV2OpenEndedStorage.sol
+++ b/src/abstracts/SablierV2OpenEndedStorage.sol
@@ -108,12 +108,12 @@ abstract contract SablierV2OpenEndedStorage is ISablierV2OpenEndedStorage {
 
     /// @inheritdoc ISablierV2OpenEndedStorage
     function isCanceled(uint256 streamId) public view override notNull(streamId) returns (bool result) {
-        result = _streams[streamId].isCanceled;
+        result = _streams[streamId].ratePerSecond == 0 && _streams[streamId].sender != address(0);
     }
 
     /// @inheritdoc ISablierV2OpenEndedStorage
     function isStream(uint256 streamId) public view returns (bool result) {
-        result = _streams[streamId].isStream;
+        result = _streams[streamId].sender != address(0);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -13,8 +13,6 @@ library OpenEnded {
     /// @param ratePerSecond The amount of assets that is increasing by every second, denoted in 18 decimals.
     /// @param recipient The address receiving the assets.
     /// @param lastTimeUpdate The Unix timestamp for the streamed amount calculation.
-    /// @param isStream Boolean indicating if the struct entity exists.
-    /// @param isCanceled Boolean indicating if the stream is canceled.
     /// @param asset The contract address of the ERC-20 asset used for streaming.
     /// @param assetDecimals The decimals of the ERC-20 asset used for streaming.
     /// @param sender The address streaming the assets, with the ability to cancel the stream.
@@ -25,8 +23,6 @@ library OpenEnded {
         // slot 1
         address recipient;
         uint40 lastTimeUpdate;
-        bool isStream;
-        bool isCanceled;
         // slot 2
         IERC20 asset;
         uint8 assetDecimals;

--- a/test/integration/create/create.t.sol
+++ b/test/integration/create/create.t.sol
@@ -93,8 +93,6 @@ contract Create_Integration_Test is Integration_Test {
             assetDecimals: 18,
             balance: 0,
             lastTimeUpdate: uint40(block.timestamp),
-            isCanceled: false,
-            isStream: true,
             recipient: users.recipient,
             sender: users.sender
         });

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -28,8 +28,6 @@ abstract contract Assertions is PRBTest {
         assertEq(a.assetDecimals, b.assetDecimals, "assetDecimals");
         assertEq(a.balance, b.balance, "balance");
         assertEq(a.lastTimeUpdate, b.lastTimeUpdate, "lastTimeUpdate");
-        assertEq(a.isCanceled, b.isCanceled, "isCanceled");
-        assertEq(a.isStream, b.isStream, "isStream");
         assertEq(a.recipient, b.recipient, "recipient");
         assertEq(a.sender, b.sender, "sender");
     }


### PR DESCRIPTION
This PR removes `isCanceled` and `isStream` fields from the `Stream` struct. Functions `isCanceled(uint256 streamId)` and `function isStream(uint256 streamId)` are modified as the following:

```solidity
function isCanceled(uint256 streamId) public view override notNull(streamId) returns (bool result) {
    result = _streams[streamId].ratePerSecond == 0 && _streams[streamId].sender != address(0);
}

function isStream(uint256 streamId) public view returns (bool result) {
    result = _streams[streamId].sender != address(0);
}
``` 

Results
--------
Function name | Max (previous) | Max (new) | Gas efficiency |
----|------|------|--------|
adjustRatePerSecond | 21008 | 19022 | 9.45% | 
cancel | 73332 |  68310 | 6.85% | 
create | 105213 |  104501 | 0.68% | 
createAndDeposit | 105012 |  104443 |  0.54% | 
deposit | 49295 |  49309 | -0.03% | 
refundFromStream | 29469 |  29483 | -0.05% | 
restartStream | 34788 |  32441 | 6.75% | 
restartStreamAndDeposit |  37156 |  35919 | 3.33% | 
withdraw | 49950 |  47964 | 3.98% | 