### PR TITLE
refactor: rename function to withdrawAtMultiple

### DIFF
--- a/src/SablierV2OpenEnded.sol
+++ b/src/SablierV2OpenEnded.sol
@@ -328,7 +328,14 @@ contract SablierV2OpenEnded is ISablierV2OpenEnded, NoDelegateCall, SablierV2Ope
     }
 
     /// @inheritdoc ISablierV2OpenEnded
-    function withdrawMultiple(uint256[] calldata streamIds, uint40[] calldata times) external override noDelegateCall {
+    function withdrawAtMultiple(
+        uint256[] calldata streamIds,
+        uint40[] calldata times
+    )
+        external
+        override
+        noDelegateCall
+    {
         // Check: there is an equal number of `streamIds` and `amounts`.
         uint256 streamIdsCount = streamIds.length;
         uint256 timesCount = times.length;

--- a/src/interfaces/ISablierV2OpenEnded.sol
+++ b/src/interfaces/ISablierV2OpenEnded.sol
@@ -393,5 +393,5 @@ interface ISablierV2OpenEnded is ISablierV2OpenEndedState {
     ///
     /// @param streamIds The IDs of the streams to withdraw from.
     /// @param times The time references to calculate the streamed amount for each stream.
-    function withdrawMultiple(uint256[] calldata streamIds, uint40[] calldata times) external;
+    function withdrawAtMultiple(uint256[] calldata streamIds, uint40[] calldata times) external;
 }

--- a/test/integration/withdraw-multiple/withdrawAtMultiple.t.sol
+++ b/test/integration/withdraw-multiple/withdrawAtMultiple.t.sol
@@ -18,7 +18,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
     }
 
     function test_RevertWhen_DelegateCall() external {
-        bytes memory callData = abi.encodeCall(ISablierV2OpenEnded.withdrawMultiple, (defaultStreamIds, times));
+        bytes memory callData = abi.encodeCall(ISablierV2OpenEnded.withdrawAtMultiple, (defaultStreamIds, times));
         expectRevertDueToDelegateCall(callData);
     }
 
@@ -28,7 +28,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2OpenEnded_WithdrawMultipleArrayCountsNotEqual.selector, 0, 1)
         );
-        openEnded.withdrawMultiple(streamIds, _times);
+        openEnded.withdrawAtMultiple(streamIds, _times);
     }
 
     modifier whenArrayCountsAreEqual() {
@@ -38,7 +38,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
     function test_WithdrawMultiple_ArrayCountsZero() external whenNotDelegateCalled whenArrayCountsAreEqual {
         uint256[] memory streamIds = new uint256[](0);
         uint40[] memory _times = new uint40[](0);
-        openEnded.withdrawMultiple(streamIds, _times);
+        openEnded.withdrawAtMultiple(streamIds, _times);
     }
 
     modifier whenArrayCountsNotZero() {
@@ -54,7 +54,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
         defaultStreamIds[0] = nullStreamId;
         defaultStreamIds[1] = nullStreamId;
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2OpenEnded_Null.selector, nullStreamId));
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertGiven_SomeNull()
@@ -65,7 +65,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
     {
         defaultStreamIds[0] = nullStreamId;
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2OpenEnded_Null.selector, nullStreamId));
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertGiven_OnlyCanceled()
@@ -77,7 +77,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
     {
         openEnded.cancel(defaultStreamIds[1]);
         expectRevertCanceled();
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertGiven_SomeCanceled()
@@ -88,7 +88,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
         givenNotNull
     {
         expectRevertCanceled();
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertWhen_OnlyWithdrawalTimesNotGreaterThanLastTimeUpdate()
@@ -109,7 +109,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
                 lastTimeUpdate
             )
         );
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertWhen_SomeWithdrawalTimesNotGreaterThanLastTimeUpdate()
@@ -131,7 +131,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
                 lastTimeUpdate
             )
         );
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertWhen_OnlyWithdrawalTimesInTheFuture()
@@ -152,7 +152,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
                 Errors.SablierV2OpenEnded_WithdrawalTimeInTheFuture.selector, futureTime, WARP_ONE_MONTH
             )
         );
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertWhen_SomeWithdrawalTimesInTheFuture()
@@ -174,7 +174,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
                 Errors.SablierV2OpenEnded_WithdrawalTimeInTheFuture.selector, futureTime, WARP_ONE_MONTH
             )
         );
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertGiven_OnlyZeroBalances()
@@ -190,7 +190,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2OpenEnded_WithdrawBalanceZero.selector, defaultStreamIds[0])
         );
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
     function test_RevertGiven_SomeZeroBalances()
@@ -208,10 +208,10 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2OpenEnded_WithdrawBalanceZero.selector, defaultStreamIds[1])
         );
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
     }
 
-    function test_WithdrawMultiple()
+    function test_withdrawAtMultiple()
         external
         whenNotDelegateCalled
         whenArrayCountsAreEqual
@@ -247,7 +247,7 @@ contract WithdrawMultiple_Integration_Concrete_Test is Integration_Test {
             withdrawAmount: WITHDRAW_AMOUNT
         });
 
-        openEnded.withdrawMultiple({ streamIds: defaultStreamIds, times: times });
+        openEnded.withdrawAtMultiple({ streamIds: defaultStreamIds, times: times });
 
         actualLastTimeUpdate = openEnded.getLastTimeUpdate(defaultStreamIds[0]);
         expectedLastTimeUpdate = WITHDRAW_TIME;

--- a/test/integration/withdraw-multiple/withdrawAtMultiple.tree
+++ b/test/integration/withdraw-multiple/withdrawAtMultiple.tree
@@ -1,4 +1,4 @@
-withdrawMultiple.t.sol
+withdrawAtMultiple.t.sol
 ├── when delegate called
 │  └── it should revert
 └── when not delegate called


### PR DESCRIPTION
In the PR https://github.com/sablier-labs/v2-open-ended/pull/75/ we should have also rename `withdrawMultiple` to `withdrawAtMultiple`, but we've missed this.

I chose the current version (`withdrawAtMultiple`) over than `withdrawMultipleAt` because we will also have `withdrawMaxMultiple`.