### PR TITLE
refactor: remove corrected time logic

### DIFF
--- a/src/interfaces/ISablierFlow.sol
+++ b/src/interfaces/ISablierFlow.sol
@@ -97,15 +97,13 @@ interface ISablierFlow is
     /// decimals.
     /// @param withdrawAmount The amount withdrawn to the recipient after subtracting the protocol fee, denoted in
     /// token's decimals.
-    /// @param snapshotTime The Unix timestamp representing the updated snapshot time.
     event WithdrawFromFlowStream(
         uint256 indexed streamId,
         address indexed to,
         IERC20 indexed token,
         address caller,
         uint128 protocolFeeAmount,
-        uint128 withdrawAmount,
-        uint40 snapshotTime
+        uint128 withdrawAmount
     );
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -391,7 +389,7 @@ interface ISablierFlow is
     /// @dev Emits a {Transfer} and {WithdrawFromFlowStream} event.
     ///
     /// Notes:
-    /// - It sets the snapshot time to the corrected time returned in `_ongoingDebtOf` function.
+    /// - It sets the snapshot time to the `block.timestamp` function.
     /// - If the protocol fee is enabled for the streaming token, the amount withdrawn is adjusted by the protocol fee.
     ///
     /// Requirements:

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -138,8 +138,7 @@ abstract contract Integration_Test is Base_Test {
         // Restores the rate per second.
         flow.adjustRatePerSecond(streamId, ratePerSecond);
 
-        // Warp to make block.timestamp match the snapshot time. This is necessary as the correct snapshot time can
-        // deviate from the block.timestamp due to precision loss.
+        // Warp to the snapshot time.
         vm.warp({ newTimestamp: flow.getSnapshotTime(streamId) });
     }
 

--- a/test/integration/concrete/batch/batch.t.sol
+++ b/test/integration/concrete/batch/batch.t.sol
@@ -346,8 +346,7 @@ contract Batch_Integration_Concrete_Test is Integration_Test {
             token: usdc,
             caller: users.sender,
             protocolFeeAmount: 0,
-            withdrawAmount: WITHDRAW_AMOUNT_6D,
-            snapshotTime: getBlockTimestamp()
+            withdrawAmount: WITHDRAW_AMOUNT_6D
         });
 
         vm.expectEmit({ emitter: address(flow) });
@@ -364,8 +363,7 @@ contract Batch_Integration_Concrete_Test is Integration_Test {
             token: usdc,
             protocolFeeAmount: 0,
             caller: users.sender,
-            withdrawAmount: WITHDRAW_AMOUNT_6D,
-            snapshotTime: getBlockTimestamp()
+            withdrawAmount: WITHDRAW_AMOUNT_6D
         });
 
         vm.expectEmit({ emitter: address(flow) });

--- a/test/integration/concrete/withdraw-max/withdrawMax.t.sol
+++ b/test/integration/concrete/withdraw-max/withdrawMax.t.sol
@@ -50,8 +50,7 @@ contract WithdrawMax_Integration_Concrete_Test is Integration_Test {
             token: IERC20(address(usdc)),
             caller: users.sender,
             protocolFeeAmount: 0,
-            withdrawAmount: expectedWithdrawAmount,
-            snapshotTime: getBlockTimestamp()
+            withdrawAmount: expectedWithdrawAmount
         });
 
         vm.expectEmit({ emitter: address(flow) });

--- a/test/integration/concrete/withdraw/withdraw.t.sol
+++ b/test/integration/concrete/withdraw/withdraw.t.sol
@@ -260,8 +260,7 @@ contract Withdraw_Integration_Concrete_Test is Integration_Test {
             token: token,
             caller: users.recipient,
             protocolFeeAmount: feeAmount,
-            withdrawAmount: withdrawAmount - feeAmount,
-            snapshotTime: getBlockTimestamp()
+            withdrawAmount: withdrawAmount - feeAmount
         });
 
         vm.expectEmit({ emitter: address(flow) });

--- a/test/integration/fuzz/adjustRatePerSecond.t.sol
+++ b/test/integration/fuzz/adjustRatePerSecond.t.sol
@@ -37,11 +37,17 @@ contract AdjustRatePerSecond_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
         // Simulate the passage of time.
         vm.warp({ newTimestamp: getBlockTimestamp() + timeJump });
 
+        uint128 previousTotalDebt = flow.totalDebtOf(streamId);
+
         // Expect the relevant error.
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_StreamPaused.selector, streamId));
 
         // Adjust the rate per second.
         flow.adjustRatePerSecond(streamId, newRatePerSecond);
+
+        assertEq(flow.ongoingDebtOf(streamId), 0, "ongoing debt");
+
+        assertEq(previousTotalDebt, flow.totalDebtOf(streamId), "rate per second");
     }
 
     /// @dev Checklist:
@@ -73,6 +79,8 @@ contract AdjustRatePerSecond_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
         // Simulate the passage of time.
         vm.warp({ newTimestamp: getBlockTimestamp() + timeJump });
 
+        uint128 previousTotalDebt = flow.totalDebtOf(streamId);
+
         UD21x18 currentRatePerSecond = flow.getRatePerSecond(streamId);
         if (newRatePerSecond.unwrap() == currentRatePerSecond.unwrap()) {
             // Expect the relevant error.
@@ -97,5 +105,9 @@ contract AdjustRatePerSecond_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
 
         // Adjust the rate per second.
         flow.adjustRatePerSecond(streamId, newRatePerSecond);
+
+        assertEq(flow.ongoingDebtOf(streamId), 0, "ongoing debt");
+
+        assertEq(previousTotalDebt, flow.totalDebtOf(streamId), "rate per second");
     }
 }

--- a/test/integration/fuzz/coveredDebtOf.t.sol
+++ b/test/integration/fuzz/coveredDebtOf.t.sol
@@ -64,9 +64,7 @@ contract CoveredDebtOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         // Assert that the covered debt equals the ongoing debt.
         uint128 actualCoveredDebt = flow.coveredDebtOf(streamId);
-        uint128 expectedCoveredDebt = ratePerSecond > getRenormalizedAmount(actualCoveredDebt, decimals)
-            ? 0
-            : getDenormalizedAmount(ratePerSecond * (warpTimestamp - MAY_1_2024), decimals);
+        uint128 expectedCoveredDebt = getDenormalizedAmount(ratePerSecond * (warpTimestamp - MAY_1_2024), decimals);
         assertEq(actualCoveredDebt, expectedCoveredDebt);
     }
 

--- a/test/integration/fuzz/ongoingDebtOf.t.sol
+++ b/test/integration/fuzz/ongoingDebtOf.t.sol
@@ -89,9 +89,7 @@ contract OngoingDebtOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         // Assert that the ongoing debt equals the expected value.
         uint128 actualOngoingDebt = flow.ongoingDebtOf(streamId);
-        uint128 expectedOngoingDebt = ratePerSecond > getRenormalizedAmount(actualOngoingDebt, decimals)
-            ? 0
-            : getDenormalizedAmount(ratePerSecond * timeJump, decimals);
+        uint128 expectedOngoingDebt = getDenormalizedAmount(ratePerSecond * timeJump, decimals);
         assertEq(actualOngoingDebt, expectedOngoingDebt, "ongoing debt");
     }
 }

--- a/test/integration/fuzz/pause.t.sol
+++ b/test/integration/fuzz/pause.t.sol
@@ -82,6 +82,8 @@ contract Pause_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
         // Assert that the stream is paused.
         assertTrue(flow.isPaused(streamId), "paused");
 
+        assertEq(flow.ongoingDebtOf(streamId), 0, "ongoing debt");
+
         // Assert that the rate per second is 0.
         assertEq(flow.getRatePerSecond(streamId), 0, "rate per second");
     }

--- a/test/integration/fuzz/refundableAmountOf.t.sol
+++ b/test/integration/fuzz/refundableAmountOf.t.sol
@@ -66,9 +66,8 @@ contract RefundableAmountOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Tes
 
         // Assert that the refundable amount same as the deposited amount minus streamed amount.
         uint128 actualRefundableAmount = flow.refundableAmountOf(streamId);
-        uint128 expectedRefundableAmount = ratePerSecond > getRenormalizedAmount(flow.ongoingDebtOf(streamId), decimals)
-            ? depositedAmount
-            : depositedAmount - getDenormalizedAmount(ratePerSecond * (warpTimestamp - MAY_1_2024), decimals);
+        uint128 expectedRefundableAmount =
+            depositedAmount - getDenormalizedAmount(ratePerSecond * (warpTimestamp - MAY_1_2024), decimals);
         assertEq(actualRefundableAmount, expectedRefundableAmount);
     }
 

--- a/test/integration/fuzz/totalDebtOf.t.sol
+++ b/test/integration/fuzz/totalDebtOf.t.sol
@@ -57,9 +57,7 @@ contract TotalDebtOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         // Assert that total debt is the ongoing debt.
         uint128 actualTotalDebt = flow.totalDebtOf(streamId);
-        uint128 expectedTotalDebt = ratePerSecond > getRenormalizedAmount(flow.ongoingDebtOf(streamId), decimals)
-            ? 0
-            : getDenormalizedAmount(ratePerSecond * timeJump, decimals);
+        uint128 expectedTotalDebt = getDenormalizedAmount(ratePerSecond * timeJump, decimals);
         assertEq(actualTotalDebt, expectedTotalDebt, "total debt");
     }
 }

--- a/test/integration/fuzz/withdraw.t.sol
+++ b/test/integration/fuzz/withdraw.t.sol
@@ -174,10 +174,7 @@ contract Withdraw_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
         }
 
         // Compute the snapshot time that will be stored post withdraw.
-        vars.expectedSnapshotTime = uint40(
-            getNormalizedAmount(vars.previousOngoingDebt, flow.getTokenDecimals(streamId))
-                / flow.getRatePerSecond(streamId).unwrap() + flow.getSnapshotTime(streamId)
-        );
+        vars.expectedSnapshotTime = getBlockTimestamp();
 
         // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(token) });
@@ -190,8 +187,7 @@ contract Withdraw_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
             token: token,
             caller: caller,
             protocolFeeAmount: vars.feeAmount,
-            withdrawAmount: withdrawAmount - vars.feeAmount,
-            snapshotTime: vars.expectedSnapshotTime
+            withdrawAmount: withdrawAmount - vars.feeAmount
         });
 
         vm.expectEmit({ emitter: address(flow) });
@@ -199,6 +195,8 @@ contract Withdraw_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         // Withdraw the tokens.
         flow.withdraw(streamId, to, withdrawAmount);
+
+        assertEq(flow.ongoingDebtOf(streamId), 0, "ongoing debt");
 
         // Assert the protocol revenue.
         vars.actualProtocolRevenue = flow.protocolRevenue(token);

--- a/test/integration/fuzz/withdrawMax.t.sol
+++ b/test/integration/fuzz/withdrawMax.t.sol
@@ -92,10 +92,7 @@ contract WithdrawMax_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         uint128 withdrawAmount = flow.withdrawableAmountOf(streamId);
 
-        uint40 expectedSnapshotTime = uint40(
-            getNormalizedAmount(flow.ongoingDebtOf(streamId), flow.getTokenDecimals(streamId))
-                / flow.getRatePerSecond(streamId).unwrap() + flow.getSnapshotTime(streamId)
-        );
+        uint40 expectedSnapshotTime = getBlockTimestamp();
 
         // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(token) });
@@ -108,8 +105,7 @@ contract WithdrawMax_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
             token: token,
             caller: caller,
             protocolFeeAmount: 0,
-            withdrawAmount: withdrawAmount,
-            snapshotTime: expectedSnapshotTime
+            withdrawAmount: withdrawAmount
         });
 
         vm.expectEmit({ emitter: address(flow) });
@@ -117,6 +113,8 @@ contract WithdrawMax_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         // Withdraw the tokens.
         flow.withdrawMax(streamId, withdrawTo);
+
+        assertEq(flow.ongoingDebtOf(streamId), 0, "ongoing debt");
 
         // It should update snapshot time.
         assertEq(flow.getSnapshotTime(streamId), expectedSnapshotTime, "snapshot time");

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -76,7 +76,6 @@ abstract contract Events {
         IERC20 indexed token,
         address caller,
         uint128 protocolFeeAmount,
-        uint128 withdrawAmount,
-        uint40 snapshotTime
+        uint128 withdrawAmount
     );
 }

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -80,11 +80,6 @@ abstract contract Utils is CommonBase, Constants, PRBMathUtils {
         return (amount * (10 ** factor)).toUint128();
     }
 
-    /// @dev Renormalizes the amount to denote it in 18 decimals.
-    function getRenormalizedAmount(uint128 amount, uint8 decimals) internal pure returns (uint128) {
-        return getNormalizedAmount(getDenormalizedAmount(getNormalizedAmount(amount, decimals), decimals), decimals);
-    }
-
     /// @dev Checks if the Foundry profile is "benchmark".
     function isBenchmarkProfile() internal view returns (bool) {
         string memory profile = vm.envOr({ name: "FOUNDRY_PROFILE", defaultValue: string("default") });


### PR DESCRIPTION
Since we have changed the `time` parameter in the `withdraw` function to an `amount` parameter, the solution introduced in this [PR](https://github.com/sablier-labs/flow/pull/220) will do more harm than good. Instead, it would introduce more discrepancies between snapshoted variables because we now calculate each amount at `block.timestamp`. Here’s why:

https://github.com/sablier-labs/flow/blob/2c59bd4d77490e345fbf8404aecfa51ffbd59cb7/src/SablierFlow.sol#L834

We now save the `totalDebt` in the `snapshotDebt` at withdrawal time. This means we won’t lose track of any debt, and updating the `snapshotTime` with `correctedTime` would cause some invariants to fail, as the “snapshot” variables are no longer synchronized (sd updated with the amount calculated at `block.timestamp`, and then `snapshotTime` recalculated). Therefore, we need to update the `snapshotTime` at the time when `snapshotDebt` is updated, i.e. `block.timestamp`.

To test it, you can introduce these assertions in the `_withdraw` function at the end (commit 2c59bd4d77490e345fbf8404aecfa51ffbd59cb7 and it would fail):

```solidity
assert(_ongoingDebtOf(streamId) == 0);
assert(totalDebt - _totalDebtOf(streamId) == balance - _streams[streamId].balance);
``` 