### PR TITLE
Feedback-fuzz-test

### DIFF
--- a/tests/integration/fuzz/WithdrawMultiple.t.sol
+++ b/tests/integration/fuzz/WithdrawMultiple.t.sol
@@ -24,47 +24,41 @@ contract WithdrawMultiple_Delay_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         withdrawCount = _bound(withdrawCount, 10, 100);
 
-        // Total stream period in a given run.
-        uint128 totalStreamPeriod;
+        uint128 sufficientDepositAmount = uint128(rps * 1 days * withdrawCount / SCALE_FACTOR);
+        deposit(streamId, sufficientDepositAmount);
 
         // Actual total amount withdrawn in a given run.
         uint256 actualTotalAmountWithdrawn;
 
-        for (uint256 i; i < withdrawCount; ++i) {
-            timeJump = boundUint40(timeJump, 1 hours, 1 weeks);
+        uint40 timeBeforeFirstWithdraw = getBlockTimestamp();
 
+        for (uint256 i; i < withdrawCount; ++i) {
+            timeJump = boundUint40(timeJump, 1 hours, 1 days);
+
+            // Warp the time.
             vm.warp({ newTimestamp: getBlockTimestamp() + timeJump });
 
-            // Deposit to the stream so that there is always enough balance.
-            resetPrank(users.sender);
-            uint256 sufficientDepositAmount = (rps * timeJump) / SCALE_FACTOR + 1;
-            deposit(streamId, uint128(sufficientDepositAmount));
-
             // Withdraw the tokens.
-            resetPrank(users.recipient);
-            uint128 amountWithdrawn = flow.withdrawMax(streamId, users.recipient);
-
-            // Update the actual amount withdrawn.
-            actualTotalAmountWithdrawn += amountWithdrawn;
-
-            // Update the time warped in the loop.
-            totalStreamPeriod += timeJump;
+            actualTotalAmountWithdrawn += flow.withdrawMax(streamId, users.recipient);
         }
+
+        // Calculate the total stream period.
+        uint40 totalStreamPeriod = getBlockTimestamp() - timeBeforeFirstWithdraw;
 
         // Calculate the desired amount.
         uint256 desiredTotalAmountWithdrawn = (rps * totalStreamPeriod) / SCALE_FACTOR;
 
         // Calculate the deviation.
-        uint256 deviation = desiredTotalAmountWithdrawn - actualTotalAmountWithdrawn;
+        uint256 deviationAmount = desiredTotalAmountWithdrawn - actualTotalAmountWithdrawn;
 
         // Calculate the stream delay.
-        uint256 streamDelay = (deviation * SCALE_FACTOR) / rps;
+        uint256 streamDelay = (deviationAmount * SCALE_FACTOR) / rps;
 
-        // Assert that the stream delay is within 10 second for the given fuzzed rps.
-        assertLe(streamDelay, 10 seconds);
+        // Assert that the stream delay is within 5 second for the given fuzzed rps.
+        assertLe(streamDelay, 5 seconds);
 
-        // Assert that the deviation is less than 1e6 USDC.
-        assertLe(deviation, 1e6);
+        // Assert that the deviation is less than 0.01e6 USDC.
+        assertLe(deviationAmount, 0.01e6);
 
         // Assert that actual amount withdrawn is always less than the desired amount.
         assertLe(actualTotalAmountWithdrawn, desiredTotalAmountWithdrawn);


### PR DESCRIPTION
### Changes

- deposit before loop
- bound timejump below 1 day
- calculate totla time stream after loop 
- remove redundant withdrawAmount var
- lower the stream delay to 5 secodns
- lower the deviation to 1 cent