### PR TITLE
refactor: deposit input parameters

### DIFF
--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -242,13 +242,16 @@ contract SablierFlow is
     /// @inheritdoc ISablierFlow
     function deposit(
         uint256 streamId,
-        uint128 amount
+        uint128 amount,
+        address sender,
+        address recipient
     )
         external
         override
         noDelegateCall
         notNull(streamId)
         notVoided(streamId)
+        notDifferentActors(streamId, sender, recipient)
         updateMetadata(streamId)
     {
         // Checks, Effects, and Interactions: deposit on stream.
@@ -279,6 +282,8 @@ contract SablierFlow is
     function depositViaBroker(
         uint256 streamId,
         uint128 totalAmount,
+        address sender,
+        address recipient,
         Broker calldata broker
     )
         external
@@ -286,6 +291,7 @@ contract SablierFlow is
         noDelegateCall
         notNull(streamId)
         notVoided(streamId)
+        notDifferentActors(streamId, sender, recipient)
         updateMetadata(streamId)
     {
         // Checks, Effects, and Interactions: deposit on stream through broker.

--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -251,9 +251,11 @@ contract SablierFlow is
         noDelegateCall
         notNull(streamId)
         notVoided(streamId)
-        notDifferentActors(streamId, sender, recipient)
         updateMetadata(streamId)
     {
+        // Check: the provided sender and recipient match the stream's sender and recipient.
+        _verifyStreamSenderRecipient(streamId, sender, recipient);
+
         // Checks, Effects, and Interactions: deposit on stream.
         _deposit(streamId, amount);
     }
@@ -291,9 +293,11 @@ contract SablierFlow is
         noDelegateCall
         notNull(streamId)
         notVoided(streamId)
-        notDifferentActors(streamId, sender, recipient)
         updateMetadata(streamId)
     {
+        // Check: the provided sender and recipient match the stream's sender and recipient.
+        _verifyStreamSenderRecipient(streamId, sender, recipient);
+
         // Checks, Effects, and Interactions: deposit on stream through broker.
         _depositViaBroker(streamId, totalAmount, broker);
     }
@@ -505,6 +509,17 @@ contract SablierFlow is
             return totalDebt - balance;
         } else {
             return 0;
+        }
+    }
+
+    /// @dev Checks whether the provided addresses matches stream's sender and recipient.
+    function _verifyStreamSenderRecipient(uint256 streamId, address sender, address recipient) internal view {
+        if (sender != _streams[streamId].sender) {
+            revert Errors.SablierFlow_NotStreamSender(sender, _streams[streamId].sender);
+        }
+
+        if (recipient != _ownerOf(streamId)) {
+            revert Errors.SablierFlow_NotStreamRecipient(recipient, _ownerOf(streamId));
         }
     }
 

--- a/src/abstracts/SablierFlowBase.sol
+++ b/src/abstracts/SablierFlowBase.sol
@@ -66,21 +66,6 @@ abstract contract SablierFlowBase is
                                       MODIFIERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Checks whether the provided addresses matches stream's sender and recipient.
-    modifier notDifferentActors(uint256 streamId, address sender, address recipient) {
-        // Check: the sender address matches the stream's sender.
-        if (sender != _streams[streamId].sender) {
-            revert Errors.SablierFlow_NotStreamSender(sender, _streams[streamId].sender);
-        }
-
-        // Check: the recipient address matches the stream's recipient.
-        if (recipient != _ownerOf(streamId)) {
-            revert Errors.SablierFlow_NotStreamRecipient(recipient, _ownerOf(streamId));
-        }
-
-        _;
-    }
-
     /// @dev Checks that `streamId` does not reference a null stream.
     modifier notNull(uint256 streamId) {
         if (!_streams[streamId].isStream) {

--- a/src/abstracts/SablierFlowBase.sol
+++ b/src/abstracts/SablierFlowBase.sol
@@ -66,6 +66,21 @@ abstract contract SablierFlowBase is
                                       MODIFIERS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @dev Checks whether the provided addresses matches stream's sender and recipient.
+    modifier notDifferentActors(uint256 streamId, address sender, address recipient) {
+        // Check: the sender address matches the stream's sender.
+        if (sender != _streams[streamId].sender) {
+            revert Errors.SablierFlow_NotStreamSender(sender, _streams[streamId].sender);
+        }
+
+        // Check: the recipient address matches the stream's recipient.
+        if (recipient != _ownerOf(streamId)) {
+            revert Errors.SablierFlow_NotStreamRecipient(recipient, _ownerOf(streamId));
+        }
+
+        _;
+    }
+
     /// @dev Checks that `streamId` does not reference a null stream.
     modifier notNull(uint256 streamId) {
         if (!_streams[streamId].isStream) {

--- a/src/interfaces/ISablierFlow.sol
+++ b/src/interfaces/ISablierFlow.sol
@@ -249,7 +249,6 @@ interface ISablierFlow is
     ///
     /// @param streamId The ID of the stream to deposit to.
     /// @param amount The deposit amount, denoted in token's decimals.
-    /// @param amount The deposit amount, in token decimals.
     /// @param sender The stream's sender address.
     /// @param recipient The stream's recipient address.
     function deposit(uint256 streamId, uint128 amount, address sender, address recipient) external;

--- a/src/interfaces/ISablierFlow.sol
+++ b/src/interfaces/ISablierFlow.sol
@@ -52,8 +52,8 @@ interface ISablierFlow is
 
     /// @notice Emitted when a stream is paused by the sender.
     /// @param streamId The ID of the stream.
-    /// @param sender The address of the stream's sender.
-    /// @param recipient The address of the stream's recipient.
+    /// @param sender The stream's sender address.
+    /// @param recipient The stream's recipient address.
     /// @param totalDebt The amount of tokens owed by the sender to the recipient, denoted in token's decimals.
     event PauseFlowStream(
         uint256 indexed streamId, address indexed sender, address indexed recipient, uint256 totalDebt
@@ -61,21 +61,21 @@ interface ISablierFlow is
 
     /// @notice Emitted when a sender is refunded from a stream.
     /// @param streamId The ID of the stream.
-    /// @param sender The address of the stream's sender.
+    /// @param sender The stream's sender address.
     /// @param amount The amount of tokens refunded to the sender, denoted in token's decimals.
     event RefundFromFlowStream(uint256 indexed streamId, address indexed sender, uint128 amount);
 
     /// @notice Emitted when a stream is restarted by the sender.
     /// @param streamId The ID of the stream.
-    /// @param sender The address of the stream's sender.
+    /// @param sender The stream's sender address.
     /// @param ratePerSecond The amount by which the debt is increasing every second, denoted as a fixed-point number
     /// where 1e18 is 1 token per second.
     event RestartFlowStream(uint256 indexed streamId, address indexed sender, UD21x18 ratePerSecond);
 
     /// @notice Emitted when a stream is voided by the sender, recipient or an approved operator.
     /// @param streamId The ID of the stream.
-    /// @param sender The address of the stream's sender.
-    /// @param recipient The address of the stream's recipient.
+    /// @param sender The stream's sender address.
+    /// @param recipient The stream's recipient address.
     /// @param caller The address that performed the void, which can be the sender, recipient or an approved operator.
     /// @param newTotalDebt The new total debt, denoted in token's decimals.
     /// @param writtenOffDebt The amount of debt written off by the caller, denoted in token's decimals.
@@ -245,10 +245,14 @@ interface ISablierFlow is
     /// - Must not be delegate called.
     /// - `streamId` must not reference a null or a voided stream.
     /// - `amount` must be greater than zero.
+    /// - `sender` and `recipient` must match the stream's sender and recipient addresses.
     ///
     /// @param streamId The ID of the stream to deposit to.
     /// @param amount The deposit amount, denoted in token's decimals.
-    function deposit(uint256 streamId, uint128 amount) external;
+    /// @param amount The deposit amount, in token decimals.
+    /// @param sender The stream's sender address.
+    /// @param recipient The stream's recipient address.
+    function deposit(uint256 streamId, uint128 amount, address sender, address recipient) external;
 
     /// @notice Deposits tokens in a stream and pauses it.
     ///
@@ -280,9 +284,18 @@ interface ISablierFlow is
     ///
     /// @param streamId The ID of the stream to deposit on.
     /// @param totalAmount The total amount, including the deposit and any broker fee, denoted in token's decimals.
+    /// @param sender The stream's sender address.
+    /// @param recipient The stream's recipient address.
     /// @param broker Struct encapsulating (i) the address of the broker assisting in creating the stream, and (ii) the
     /// percentage fee paid to the broker from `totalAmount`, denoted as a fixed-point percentage.
-    function depositViaBroker(uint256 streamId, uint128 totalAmount, Broker calldata broker) external;
+    function depositViaBroker(
+        uint256 streamId,
+        uint128 totalAmount,
+        address sender,
+        address recipient,
+        Broker calldata broker
+    )
+        external;
 
     /// @notice Pauses the stream.
     ///

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -39,17 +39,17 @@ library Errors {
     /// @notice Thrown when an unexpected error occurs during the calculation of an amount.
     error SablierFlow_InvalidCalculation(uint256 streamId, uint128 availableAmount, uint128 amount);
 
-    /// @notice Thrown when the ID references a null stream.
-    error SablierFlow_Null(uint256 streamId);
-
-    /// @notice Thrown when trying to withdraw an amount greater than the withdrawable amount.
-    error SablierFlow_Overdraw(uint256 streamId, uint128 amount, uint128 withdrawableAmount);
-
     /// @notice Thrown when the recipient address does not match the stream's recipient.
     error SablierFlow_NotStreamRecipient(address recipient, address streamRecipient);
 
     /// @notice Thrown when the sender address does not match the stream's sender.
     error SablierFlow_NotStreamSender(address sender, address streamSender);
+
+    /// @notice Thrown when the ID references a null stream.
+    error SablierFlow_Null(uint256 streamId);
+
+    /// @notice Thrown when trying to withdraw an amount greater than the withdrawable amount.
+    error SablierFlow_Overdraw(uint256 streamId, uint128 amount, uint128 withdrawableAmount);
 
     /// @notice Thrown when trying to change the rate per second with the same rate per second.
     error SablierFlow_RatePerSecondNotDifferent(uint256 streamId, UD21x18 ratePerSecond);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -45,6 +45,12 @@ library Errors {
     /// @notice Thrown when trying to withdraw an amount greater than the withdrawable amount.
     error SablierFlow_Overdraw(uint256 streamId, uint128 amount, uint128 withdrawableAmount);
 
+    /// @notice Thrown when the recipient address does not match the stream's recipient.
+    error SablierFlow_NotStreamRecipient(address recipient, address streamRecipient);
+
+    /// @notice Thrown when the sender address does not match the stream's sender.
+    error SablierFlow_NotStreamSender(address sender, address streamSender);
+
     /// @notice Thrown when trying to change the rate per second with the same rate per second.
     error SablierFlow_RatePerSecondNotDifferent(uint256 streamId, UD21x18 ratePerSecond);
 

--- a/tests/fork/Flow.t.sol
+++ b/tests/fork/Flow.t.sol
@@ -357,7 +357,7 @@ contract Flow_Fork_Test is Fork_Test {
         expectCallToTransferFrom({ token: token, from: sender, to: address(flow), amount: depositAmount });
 
         // Make the deposit.
-        flow.deposit(streamId, depositAmount);
+        flow.deposit(streamId, depositAmount, sender, flow.getRecipient(streamId));
 
         // Assert that the token balance of stream has been updated.
         vars.actualTokenBalance = token.balanceOf(address(flow));

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -88,7 +88,12 @@ abstract contract Fork_Test is Base_Test {
         resetPrank({ msgSender: sender });
         deal({ token: address(token), to: sender, give: depositAmount });
         safeApprove(depositAmount);
-        flow.deposit({ streamId: streamId, amount: depositAmount });
+        flow.deposit({
+            streamId: streamId,
+            amount: depositAmount,
+            sender: sender,
+            recipient: flow.getRecipient(streamId)
+        });
     }
 
     /// @dev Use a low-level call to ignore reverts in case of USDT.

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -112,7 +112,7 @@ abstract contract Integration_Test is Base_Test {
         deal({ token: address(token), to: users.sender, give: UINT128_MAX });
         token.approve(address(flow), UINT128_MAX);
 
-        flow.deposit(streamId, amount);
+        flow.deposit(streamId, amount, users.sender, users.recipient);
     }
 
     function depositDefaultAmount(uint256 streamId) internal {

--- a/tests/integration/concrete/adjust-rate-per-second/adjustRatePerSecond.t.sol
+++ b/tests/integration/concrete/adjust-rate-per-second/adjustRatePerSecond.t.sol
@@ -85,7 +85,7 @@ contract AdjustRatePerSecond_Integration_Concrete_Test is Integration_Test {
         whenCallerSender
         whenNewRatePerSecondNotEqualsCurrentRatePerSecond
     {
-        flow.deposit(defaultStreamId, DEPOSIT_AMOUNT_6D);
+        flow.deposit(defaultStreamId, DEPOSIT_AMOUNT_6D, users.sender, users.recipient);
 
         UD21x18 actualRatePerSecond = flow.getRatePerSecond(defaultStreamId);
         UD21x18 expectedRatePerSecond = RATE_PER_SECOND;

--- a/tests/integration/concrete/batch/batch.t.sol
+++ b/tests/integration/concrete/batch/batch.t.sol
@@ -53,7 +53,7 @@ contract Batch_Integration_Concrete_Test is Integration_Test {
 
         // The calls declared as bytes
         bytes[] memory calls = new bytes[](1);
-        calls[0] = abi.encodeCall(flow.deposit, (streamId, DEPOSIT_AMOUNT_6D));
+        calls[0] = abi.encodeCall(flow.deposit, (streamId, DEPOSIT_AMOUNT_6D, users.sender, users.recipient));
 
         bytes memory expectedRevertData = abi.encodeWithSelector(
             Errors.BatchError.selector, abi.encodeWithSignature("Error(string)", "ERC20: insufficient allowance")
@@ -176,8 +176,8 @@ contract Batch_Integration_Concrete_Test is Integration_Test {
     function test_Batch_DepositMultiple() external {
         // The calls declared as bytes
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeCall(flow.deposit, (defaultStreamIds[0], DEPOSIT_AMOUNT_6D));
-        calls[1] = abi.encodeCall(flow.deposit, (defaultStreamIds[1], DEPOSIT_AMOUNT_6D));
+        calls[0] = abi.encodeCall(flow.deposit, (defaultStreamIds[0], DEPOSIT_AMOUNT_6D, users.sender, users.recipient));
+        calls[1] = abi.encodeCall(flow.deposit, (defaultStreamIds[1], DEPOSIT_AMOUNT_6D, users.sender, users.recipient));
 
         // It should emit 2 {Transfer}, 2 {DepositFlowStream}, 2 {MetadataUpdate} events.
 

--- a/tests/integration/concrete/deposit-via-broker/depositViaBroker.tree
+++ b/tests/integration/concrete/deposit-via-broker/depositViaBroker.tree
@@ -8,23 +8,29 @@ DepositViaBroker_Integration_Concrete_Test
       ├── given voided
       │  └── it should revert
       └── given not voided
-         ├── when broker fee greater than max fee
+         ├── when sender not match
          │  └── it should revert
-         └── when broker fee not greater than max fee
-            ├── when broke address zero
+         └── when sender matches
+            ├── when recipient not match
             │  └── it should revert
-            └── when broker address not zero
-               ├── when total amount zero
+            └── when recipient matches
+               ├── when broker fee greater than max fee
                │  └── it should revert
-               └── when total amount not zero
-                  ├── when token misses ERC20 return
-                  │  └── it should make the deposit
-                  └── when token not miss ERC20 return
-                     ├── given token has 18 decimals
-                     │  ├── it should update the stream balance
-                     │  ├── it should perform the ERC20 transfers
-                     │  └── it should emit 2 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
-                     └── given token not have 18 decimals
-                        ├── it should update the stream balance
-                        ├── it should perform the ERC20 transfers
-                        └── it should emit 2 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
+               └── when broker fee not greater than max fee
+                  ├── when broke address zero
+                  │  └── it should revert
+                  └── when broker address not zero
+                     ├── when total amount zero
+                     │  └── it should revert
+                     └── when total amount not zero
+                        ├── when token misses ERC20 return
+                        │  └── it should make the deposit
+                        └── when token not miss ERC20 return
+                           ├── given token has 18 decimals
+                           │  ├── it should update the stream balance
+                           │  ├── it should perform the ERC20 transfers
+                           │  └── it should emit 2 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
+                           └── given token not have 18 decimals
+                              ├── it should update the stream balance
+                              ├── it should perform the ERC20 transfers
+                              └── it should emit 2 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events

--- a/tests/integration/concrete/deposit/deposit.t.sol
+++ b/tests/integration/concrete/deposit/deposit.t.sol
@@ -11,23 +11,51 @@ import { Integration_Test } from "../../Integration.t.sol";
 
 contract Deposit_Integration_Concrete_Test is Integration_Test {
     function test_RevertWhen_DelegateCall() external {
-        bytes memory callData = abi.encodeCall(flow.deposit, (defaultStreamId, DEPOSIT_AMOUNT_6D));
+        bytes memory callData =
+            abi.encodeCall(flow.deposit, (defaultStreamId, DEPOSIT_AMOUNT_6D, users.sender, users.recipient));
         expectRevert_DelegateCall(callData);
     }
 
     function test_RevertGiven_Null() external whenNoDelegateCall {
-        bytes memory callData = abi.encodeCall(flow.deposit, (nullStreamId, DEPOSIT_AMOUNT_6D));
+        bytes memory callData =
+            abi.encodeCall(flow.deposit, (nullStreamId, DEPOSIT_AMOUNT_6D, users.sender, users.recipient));
         expectRevert_Null(callData);
     }
 
     function test_RevertGiven_Voided() external whenNoDelegateCall givenNotNull {
-        bytes memory callData = abi.encodeCall(flow.deposit, (defaultStreamId, DEPOSIT_AMOUNT_6D));
+        bytes memory callData =
+            abi.encodeCall(flow.deposit, (defaultStreamId, DEPOSIT_AMOUNT_6D, users.sender, users.recipient));
         expectRevert_Voided(callData);
     }
 
-    function test_RevertWhen_DepositAmountZero() external whenNoDelegateCall givenNotNull givenNotVoided {
+    function test_RevertWhen_SenderNotMatch() external whenNoDelegateCall givenNotNull givenNotVoided {
+        vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_NotStreamSender.selector, users.eve, users.sender));
+        flow.deposit(defaultStreamId, DEPOSIT_AMOUNT_6D, users.eve, users.recipient);
+    }
+
+    function test_RevertWhen_RecipientNotMatch()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        givenNotVoided
+        whenSenderMatches
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.SablierFlow_NotStreamRecipient.selector, users.eve, users.recipient)
+        );
+        flow.deposit(defaultStreamId, DEPOSIT_AMOUNT_6D, users.sender, users.eve);
+    }
+
+    function test_RevertWhen_DepositAmountZero()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        givenNotVoided
+        whenSenderMatches
+        whenRecipientMatches
+    {
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_DepositAmountZero.selector, defaultStreamId));
-        flow.deposit(defaultStreamId, 0);
+        flow.deposit(defaultStreamId, 0, users.sender, users.recipient);
     }
 
     function test_WhenTokenMissesERC20Return()
@@ -35,6 +63,8 @@ contract Deposit_Integration_Concrete_Test is Integration_Test {
         whenNoDelegateCall
         givenNotNull
         givenNotVoided
+        whenSenderMatches
+        whenRecipientMatches
         whenDepositAmountNotZero
     {
         uint256 streamId = createDefaultStream(IERC20(address(usdt)));
@@ -48,6 +78,8 @@ contract Deposit_Integration_Concrete_Test is Integration_Test {
         whenNoDelegateCall
         givenNotNull
         givenNotVoided
+        whenSenderMatches
+        whenRecipientMatches
         whenDepositAmountNotZero
         whenTokenNotMissERC20Return
     {
@@ -61,6 +93,8 @@ contract Deposit_Integration_Concrete_Test is Integration_Test {
         whenNoDelegateCall
         givenNotNull
         givenNotVoided
+        whenSenderMatches
+        whenRecipientMatches
         whenDepositAmountNotZero
         whenTokenNotMissERC20Return
     {
@@ -83,7 +117,7 @@ contract Deposit_Integration_Concrete_Test is Integration_Test {
 
         // It should perform the ERC-20 transfer.
         expectCallToTransferFrom({ token: token, from: users.sender, to: address(flow), amount: depositAmount });
-        flow.deposit({ streamId: streamId, amount: depositAmount });
+        flow.deposit(streamId, depositAmount, users.sender, users.recipient);
 
         // It should update the stream balance.
         uint128 actualStreamBalance = flow.getBalance(streamId);

--- a/tests/integration/concrete/deposit/deposit.tree
+++ b/tests/integration/concrete/deposit/deposit.tree
@@ -8,20 +8,26 @@ Deposit_Integration_Concrete_Test
       ├── given voided
       │  └── it should revert
       └── given not voided
-         ├── when deposit amount zero
+         ├── when sender not match
          │  └── it should revert
-         └── when deposit amount not zero
-            ├── when token misses ERC20 return
-            │  └── it should make the deposit
-            └── when token not miss ERC20 return
-               ├── given token has 18 decimals
-               │  ├── it should update the stream balance
-               │  ├── it should increase the aggregate amount
-               │  ├── it should perform the ERC20 transfer
-               │  └── it should emit 1 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
-               └── given token not have 18 decimals
-                  ├── it should update the stream balance
-                  ├── it should increase the aggregate amount
-                  ├── it should perform the ERC20 transfer
-                  └── it should emit 1 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
+         └── when sender matches
+            ├── when recipient not match
+            │  └── it should revert
+            └── when recipient matches
+               ├── when deposit amount zero
+               │  └── it should revert
+               └── when deposit amount not zero
+                  ├── when token misses ERC20 return
+                  │  └── it should make the deposit
+                  └── when token not miss ERC20 return
+                     ├── given token has 18 decimals
+                     │  ├── it should update the stream balance
+                     │  ├── it should increase the aggregate amount
+                     │  ├── it should perform the ERC20 transfer
+                     │  └── it should emit 1 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
+                     └── given token not have 18 decimals
+                        ├── it should update the stream balance
+                        ├── it should increase the aggregate amount
+                        ├── it should perform the ERC20 transfer
+                        └── it should emit 1 {Transfer}, 1 {DepositFlowStream}, 1 {MetadataUpdate} events
 

--- a/tests/integration/fuzz/depletionTimeOf.t.sol
+++ b/tests/integration/fuzz/depletionTimeOf.t.sol
@@ -34,7 +34,7 @@ contract DepletionTimeOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
 
         // Assert that depletion time equals expected value.
         uint256 actualDepletionTime = flow.depletionTimeOf(streamId);
-        if (getBlockTimestamp() > OCT_1_2024 + solvencyPeriod) {
+        if (getBlockTimestamp() >= OCT_1_2024 + solvencyPeriod) {
             assertEq(actualDepletionTime, 0, "depletion time");
 
             // Assert that uncovered debt is greater than 0.

--- a/tests/integration/fuzz/deposit.t.sol
+++ b/tests/integration/fuzz/deposit.t.sol
@@ -68,7 +68,7 @@ contract Deposit_Integration_Fuzz_Test is Shared_Integration_Fuzz_Test {
         expectCallToTransferFrom({ token: token, from: caller, to: address(flow), amount: depositAmount });
 
         // Make the deposit.
-        flow.deposit(streamId, depositAmount);
+        flow.deposit(streamId, depositAmount, users.sender, users.recipient);
 
         // Assert that the token balance of stream has been updated.
         uint256 actualTokenBalance = token.balanceOf(address(flow));

--- a/tests/invariant/handlers/FlowHandler.sol
+++ b/tests/invariant/handlers/FlowHandler.sol
@@ -142,7 +142,7 @@ contract FlowHandler is BaseHandler {
             streamId: currentStreamId,
             amount: depositAmount,
             sender: currentSender,
-            recipient: currentRecipient
+            recipient: flow.getRecipient(currentStreamId)
         });
 
         // Update the deposited amount.

--- a/tests/invariant/handlers/FlowHandler.sol
+++ b/tests/invariant/handlers/FlowHandler.sol
@@ -138,7 +138,12 @@ contract FlowHandler is BaseHandler {
         token.approve({ spender: address(flow), value: depositAmount });
 
         // Deposit into the stream.
-        flow.deposit({ streamId: currentStreamId, amount: depositAmount });
+        flow.deposit({
+            streamId: currentStreamId,
+            amount: depositAmount,
+            sender: currentSender,
+            recipient: currentRecipient
+        });
 
         // Update the deposited amount.
         flowStore.updateStreamDepositedAmountsSum(currentStreamId, token, depositAmount);

--- a/tests/utils/Modifiers.sol
+++ b/tests/utils/Modifiers.sol
@@ -86,6 +86,14 @@ abstract contract Modifiers {
         _;
     }
 
+    modifier whenRecipientMatches() {
+        _;
+    }
+
+    modifier whenSenderMatches() {
+        _;
+    }
+
     modifier whenTotalAmountNotZero() {
         _;
     }


### PR DESCRIPTION
Depends on https://github.com/sablier-labs/flow/pull/312 

Closes https://github.com/sablier-labs/flow/issues/300

**Note:** The reason for not including `sender` and `recipient` parameters in `depositAndPause` and `restartAndDeposit` is that only the stream's sender can call these functions. Therefore, it is implicitly protected from reorg attacks. If we add any check, it would only be for the recipient. Let me know if you find that useful.