### PR TITLE
fix: depletionTimeOf calculation

### DIFF
--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -74,21 +74,30 @@ contract SablierFlow is
 
         uint256 snapshotDebtScaled = _streams[streamId].snapshotDebtScaled;
 
-        // If the stream has uncovered debt, return zero.
-        if (snapshotDebtScaled + _ongoingDebtScaledOf(streamId) > balanceScaled) {
+        uint256 oneWeiScaled = Helpers.scaleAmount({ amount: 1, decimals: tokenDecimals });
+        // If the total debt exceeds balance, return zero.
+        if (snapshotDebtScaled + _ongoingDebtScaledOf(streamId) >= balanceScaled + oneWeiScaled) {
             return 0;
         }
 
-        // Depletion time is defined as the UNIX timestamp beyond which the total debt exceeds stream balance.
-        // So we calculate it by solving: debt at depletion time = stream balance + 1. This ensures that we find the
-        // lowest timestamp at which the debt exceeds the balance.
+        // Depletion time is defined as the UNIX timestamp at which the total debt exceeds stream balance by 1 wei. So
+        // we calculate it by solving: total debt at depletion time = stream balance + 1. This ensures that we find the
+        // lowest timestamp at which the total debt exceeds the stream balance.
         // Safe to use unchecked because the calculations cannot overflow or underflow.
         unchecked {
             uint256 solvencyAmount =
                 balanceScaled - snapshotDebtScaled + Helpers.scaleAmount({ amount: 1, decimals: tokenDecimals });
             uint256 solvencyPeriod = solvencyAmount / _streams[streamId].ratePerSecond.unwrap();
 
-            depletionTime = _streams[streamId].snapshotTime + solvencyPeriod;
+            uint256 carry = solvencyAmount % _streams[streamId].ratePerSecond.unwrap();
+
+            if (carry == 0) {
+                depletionTime = _streams[streamId].snapshotTime + solvencyPeriod;
+            }
+            // Rounding up before returning since the division by the rate per second has round down the result.
+            else {
+                depletionTime = _streams[streamId].snapshotTime + solvencyPeriod + 1;
+            }
         }
     }
 

--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -72,6 +72,9 @@ contract SablierFlow is
         uint8 tokenDecimals = _streams[streamId].tokenDecimals;
         uint256 balanceScaled = Helpers.scaleAmount({ amount: balance, decimals: tokenDecimals });
         uint256 snapshotDebtScaled = _streams[streamId].snapshotDebtScaled;
+
+        // MVT represents Minimum Value Transferable, the smallest amount of token that can be transferred, which is
+        // always 1 in token's decimal.
         uint256 oneMVTScaled = Helpers.scaleAmount({ amount: 1, decimals: tokenDecimals });
 
         // If the total debt exceeds balance, return zero.

--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -72,21 +72,21 @@ contract SablierFlow is
         uint8 tokenDecimals = _streams[streamId].tokenDecimals;
         uint256 balanceScaled = Helpers.scaleAmount({ amount: balance, decimals: tokenDecimals });
         uint256 snapshotDebtScaled = _streams[streamId].snapshotDebtScaled;
-        uint256 oneWeiScaled = Helpers.scaleAmount({ amount: 1, decimals: tokenDecimals });
+        uint256 oneMVTScaled = Helpers.scaleAmount({ amount: 1, decimals: tokenDecimals });
 
         // If the total debt exceeds balance, return zero.
-        if (snapshotDebtScaled + _ongoingDebtScaledOf(streamId) >= balanceScaled + oneWeiScaled) {
+        if (snapshotDebtScaled + _ongoingDebtScaledOf(streamId) >= balanceScaled + oneMVTScaled) {
             return 0;
         }
 
         uint256 ratePerSecond = _streams[streamId].ratePerSecond.unwrap();
 
-        // Depletion time is defined as the UNIX timestamp at which the total debt exceeds stream balance by 1 wei. So
-        // we calculate it by solving: total debt at depletion time = stream balance + 1. This ensures that we find the
-        // lowest timestamp at which the total debt exceeds the stream balance.
+        // Depletion time is defined as the UNIX timestamp at which the total debt exceeds stream balance by 1 unit of
+        // token (mvt). So we calculate it by solving: total debt at depletion time = stream balance + 1. This ensures
+        // that we find the lowest timestamp at which the total debt exceeds the stream balance.
         // Safe to use unchecked because the calculations cannot overflow or underflow.
         unchecked {
-            uint256 solvencyAmount = balanceScaled - snapshotDebtScaled + oneWeiScaled;
+            uint256 solvencyAmount = balanceScaled - snapshotDebtScaled + oneMVTScaled;
             uint256 solvencyPeriod = solvencyAmount / ratePerSecond;
 
             // If the division is exact, return the depletion time.

--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -89,12 +89,11 @@ contract SablierFlow is
             uint256 solvencyAmount = balanceScaled - snapshotDebtScaled + oneWeiScaled;
             uint256 solvencyPeriod = solvencyAmount / ratePerSecond;
 
-            uint256 carry = solvencyAmount % ratePerSecond;
-
-            if (carry == 0) {
+            // If the division is exact, return the depletion time.
+            if (solvencyAmount % ratePerSecond == 0) {
                 depletionTime = _streams[streamId].snapshotTime + solvencyPeriod;
             }
-            // Rounding up before returning since the division by the rate per second has round down the result.
+            // Otherwise, round up before returning since the division by rate per second has round down the result.
             else {
                 depletionTime = _streams[streamId].snapshotTime + solvencyPeriod + 1;
             }

--- a/src/interfaces/ISablierFlow.sol
+++ b/src/interfaces/ISablierFlow.sol
@@ -115,8 +115,8 @@ interface ISablierFlow is
     /// @param streamId The stream ID for the query.
     function coveredDebtOf(uint256 streamId) external view returns (uint128 coveredDebt);
 
-    /// @notice Returns the time at which the stream will deplete its balance and start to accumulate uncovered debt. If
-    /// there already is uncovered debt, it returns zero.
+    /// @notice Returns the time at which the total debt exceeds stream balance. If the total debt is less than
+    /// or equal to stream balance, it returns 0.
     /// @dev Reverts if `streamId` references a paused or a null stream.
     /// @param streamId The stream ID for the query.
     function depletionTimeOf(uint256 streamId) external view returns (uint256 depletionTime);

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22;
 
+import { UD21x18 } from "@prb/math/src/UD21x18.sol";
+
 import { Integration_Test } from "../../Integration.t.sol";
 
 contract DepletionTimeOf_Integration_Concrete_Test is Integration_Test {
@@ -15,21 +17,49 @@ contract DepletionTimeOf_Integration_Concrete_Test is Integration_Test {
     }
 
     function test_GivenBalanceZero() external view givenNotNull givenNotPaused {
-        // It should return 0
-        uint256 depletionTime = flow.depletionTimeOf(defaultStreamId);
-        assertEq(depletionTime, 0, "depletion time");
+        // It should return 0.
+        uint256 actualDepletionTime = flow.depletionTimeOf(defaultStreamId);
+        assertEq(actualDepletionTime, 0, "depletion time");
     }
 
     function test_GivenUncoveredDebt() external givenNotNull givenNotPaused givenBalanceNotZero {
-        vm.warp({ newTimestamp: WARP_SOLVENCY_PERIOD + 1 });
-        // It should return 0
-        uint256 depletionTime = flow.depletionTimeOf(defaultStreamId);
-        assertEq(depletionTime, 0, "depletion time");
+        vm.warp({ newTimestamp: WARP_SOLVENCY_PERIOD });
+
+        // Check that uncovered debt is greater than 0.
+        assertGt(flow.uncoveredDebtOf(defaultStreamId), 0);
+
+        // It should return 0.
+        uint256 actualDepletionTime = flow.depletionTimeOf(defaultStreamId);
+        assertEq(actualDepletionTime, 0, "depletion time");
     }
 
-    function test_GivenNoUncoveredDebt() external givenNotNull givenNotPaused givenBalanceNotZero {
-        // It should return the time at which the stream depletes its balance
-        uint40 depletionTime = uint40(flow.depletionTimeOf(defaultStreamId));
-        assertEq(depletionTime, WARP_SOLVENCY_PERIOD, "depletion time");
+    modifier givenNoUncoveredDebt() {
+        _;
+    }
+
+    function test_WhenExactDivision() external givenNotNull givenNotPaused givenBalanceNotZero givenNoUncoveredDebt {
+        // Create a stream with a rate per second such that the deposit amount produces no remainder when divided by the
+        // rate per second.
+        UD21x18 rps = UD21x18.wrap(2e18);
+        uint256 streamId = createDefaultStream(rps, usdc);
+        depositDefaultAmount(streamId);
+        uint256 solvencyPeriod = DEPOSIT_AMOUNT_18D / rps.unwrap();
+
+        // It should return the time at which the total debt exceeds the balance.
+        uint40 actualDepletionTime = uint40(flow.depletionTimeOf(streamId));
+        uint40 exptectedDepletionTime = WARP_ONE_MONTH + uint40(solvencyPeriod + 1);
+        assertEq(actualDepletionTime, exptectedDepletionTime, "depletion time");
+    }
+
+    function test_WhenNotExactDivision()
+        external
+        givenNotNull
+        givenNotPaused
+        givenBalanceNotZero
+        givenNoUncoveredDebt
+    {
+        // It should return the time at which the total debt exceeds the balance.
+        uint40 actualDepletionTime = uint40(flow.depletionTimeOf(defaultStreamId));
+        assertEq(actualDepletionTime, WARP_SOLVENCY_PERIOD, "depletion time");
     }
 }

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
@@ -23,7 +23,8 @@ contract DepletionTimeOf_Integration_Concrete_Test is Integration_Test {
     }
 
     function test_GivenUncoveredDebt() external givenNotNull givenNotPaused givenBalanceNotZero {
-        vm.warp({ newTimestamp: WARP_SOLVENCY_PERIOD });
+        uint256 depletionTimestamp = WARP_SOLVENCY_PERIOD + 1;
+        vm.warp({ newTimestamp: depletionTimestamp });
 
         // Check that uncovered debt is greater than 0.
         assertGt(flow.uncoveredDebtOf(defaultStreamId), 0);
@@ -60,6 +61,7 @@ contract DepletionTimeOf_Integration_Concrete_Test is Integration_Test {
     {
         // It should return the time at which the total debt exceeds the balance.
         uint40 actualDepletionTime = uint40(flow.depletionTimeOf(defaultStreamId));
-        assertEq(actualDepletionTime, WARP_SOLVENCY_PERIOD, "depletion time");
+        uint256 expectedDepletionTime = WARP_SOLVENCY_PERIOD + 1;
+        assertEq(actualDepletionTime, expectedDepletionTime, "depletion time");
     }
 }

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.tree
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.tree
@@ -11,4 +11,7 @@ DepletionTimeOf_Integration_Concrete_Test
          ├── given uncovered debt
          │  └── it should return 0
          └── given no uncovered debt
-            └── it should return the time at which the stream depletes its balance
+            ├── when exact division
+            │  └── it should return the time at which the total debt exceeds the balance
+            └── when not exact division
+               └── it should return the time at which the total debt exceeds the balance

--- a/tests/invariant/Flow.t.sol
+++ b/tests/invariant/Flow.t.sol
@@ -333,7 +333,7 @@ contract Flow_Invariant_Test is Base_Test {
     }
 
     /// @dev For non-voided streams, the expected streamed amount should be greater than or equal to the sum of total
-    /// debt and withdrawn amount. And, the difference between the two should not exceed 10 wei.
+    /// debt and withdrawn amount. And, the difference between the two should not exceed 10 mvt.
     function invariant_TotalStreamedEqTotalDebtPlusWithdrawn() external view {
         uint256 lastStreamId = flowStore.lastStreamId();
         for (uint256 i = 0; i < lastStreamId; ++i) {

--- a/tests/utils/Constants.sol
+++ b/tests/utils/Constants.sol
@@ -44,8 +44,10 @@ abstract contract Constants {
     // Time
     uint40 internal constant OCT_1_2024 = 1_727_740_800;
     uint40 internal constant ONE_MONTH = 30 days; // "30/360" convention
-    uint40 internal constant SOLVENCY_PERIOD = uint40(DEPOSIT_AMOUNT_18D / RATE_PER_SECOND_U128); // 578 days
+    // Solvency period is 49999999.999999 seconds.
+    uint40 internal constant SOLVENCY_PERIOD = uint40(DEPOSIT_AMOUNT_18D / RATE_PER_SECOND_U128); // ~578 days
     uint40 internal constant WARP_ONE_MONTH = OCT_1_2024 + ONE_MONTH;
-    uint40 internal constant WARP_SOLVENCY_PERIOD = OCT_1_2024 + SOLVENCY_PERIOD;
+    // Warping to the end of the solvency period + 1 second at which uncovered debt becomes greater than 0.
+    uint40 internal constant WARP_SOLVENCY_PERIOD = OCT_1_2024 + SOLVENCY_PERIOD + 1;
     uint40 internal constant WITHDRAW_TIME = OCT_1_2024 + 2_500_000;
 }

--- a/tests/utils/Constants.sol
+++ b/tests/utils/Constants.sol
@@ -47,7 +47,7 @@ abstract contract Constants {
     // Solvency period is 49999999.999999 seconds.
     uint40 internal constant SOLVENCY_PERIOD = uint40(DEPOSIT_AMOUNT_18D / RATE_PER_SECOND_U128); // ~578 days
     uint40 internal constant WARP_ONE_MONTH = OCT_1_2024 + ONE_MONTH;
-    // Warping to the end of the solvency period + 1 second at which uncovered debt becomes greater than 0.
-    uint40 internal constant WARP_SOLVENCY_PERIOD = OCT_1_2024 + SOLVENCY_PERIOD + 1;
+    // The following variable represents the timestamp at which the stream depletes all its balance.
+    uint40 internal constant WARP_SOLVENCY_PERIOD = OCT_1_2024 + SOLVENCY_PERIOD;
     uint40 internal constant WITHDRAW_TIME = OCT_1_2024 + 2_500_000;
 }


### PR DESCRIPTION
There was a small discrepancy between the definition of "depletion timestamp" and its implementation.

Depletion time is defined as the UNIX timestamp at which the total debt exceeds stream balance by 1 wei. That is, at depletion time, $\text{total debt} = \text{stream balance} + 1$. This also means that at depletion time, $\text{uncovered debt} = 1$. At depletion time, the streamed accrues 1 wei of uncovered debt. Therefore, this PR closes the gap between the definition and the implementation.

Therefore, consider the following cases and the expected results:

### Changelog
- Adds clarity to the definition of `depletionTimeOf` function
- Adds `+ 1` to the returned value of `depletionTimeOf` if division is not exact
- Compare values 1 second before, at, and 1 second after depletion timestamp in fuzz tests