### PR TITLE
feat: revert depletionTimeOf if balance is zero

### DIFF
--- a/src/SablierFlow.sol
+++ b/src/SablierFlow.sol
@@ -64,9 +64,9 @@ contract SablierFlow is
     {
         uint128 balance = _streams[streamId].balance;
 
-        // If the stream balance is zero, return zero.
+        // If the stream balance is zero, revert to avoid ambiguity from a depleting stream.
         if (balance == 0) {
-            return 0;
+            revert Errors.SablierFlow_StreamBalanceZero(streamId);
         }
 
         uint8 tokenDecimals = _streams[streamId].tokenDecimals;

--- a/src/interfaces/ISablierFlow.sol
+++ b/src/interfaces/ISablierFlow.sol
@@ -119,7 +119,9 @@ interface ISablierFlow is
 
     /// @notice Returns the time at which the total debt exceeds stream balance. If the total debt is less than
     /// or equal to stream balance, it returns 0.
-    /// @dev Reverts if `streamId` references a paused or a null stream.
+    /// @dev Reverts on the following conditions:
+    /// - If `streamId` references a paused or a null stream.
+    /// - If stream balance is zero.
     /// @param streamId The stream ID for the query.
     function depletionTimeOf(uint256 streamId) external view returns (uint256 depletionTime);
 

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -63,6 +63,9 @@ library Errors {
     /// @notice Thrown when trying to create a stream with the sender as the zero address.
     error SablierFlow_SenderZeroAddress();
 
+    /// @notice Thrown when trying to get depletion time of a stream with zero balance.
+    error SablierFlow_StreamBalanceZero(uint256 streamId);
+
     /// @notice Thrown when trying to perform an action with a paused stream.
     error SablierFlow_StreamPaused(uint256 streamId);
 

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { UD21x18 } from "@prb/math/src/UD21x18.sol";
+import { Errors } from "src/libraries/Errors.sol";
 
 import { Integration_Test } from "../../Integration.t.sol";
 
@@ -16,10 +17,9 @@ contract DepletionTimeOf_Integration_Concrete_Test is Integration_Test {
         expectRevert_Paused(callData);
     }
 
-    function test_GivenBalanceZero() external view givenNotNull givenNotPaused {
-        // It should return 0.
-        uint256 actualDepletionTime = flow.depletionTimeOf(defaultStreamId);
-        assertEq(actualDepletionTime, 0, "depletion time");
+    function test_GivenBalanceZero() external givenNotNull givenNotPaused {
+        vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_StreamBalanceZero.selector, defaultStreamId));
+        flow.depletionTimeOf(defaultStreamId);
     }
 
     function test_GivenUncoveredDebt() external givenNotNull givenNotPaused givenBalanceNotZero {

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
@@ -17,7 +17,7 @@ contract DepletionTimeOf_Integration_Concrete_Test is Integration_Test {
         expectRevert_Paused(callData);
     }
 
-    function test_GivenBalanceZero() external givenNotNull givenNotPaused {
+    function test_RevertGiven_BalanceZero() external givenNotNull givenNotPaused {
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_StreamBalanceZero.selector, defaultStreamId));
         flow.depletionTimeOf(defaultStreamId);
     }

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.tree
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.tree
@@ -6,7 +6,7 @@ DepletionTimeOf_Integration_Concrete_Test
    │  └── it should revert
    └── given not paused
       ├── given balance zero
-      │  └── it should return 0
+      │  └── it should revert
       └── given balance not zero
          ├── given uncovered debt
          │  └── it should return 0


### PR DESCRIPTION
Closes https://github.com/sablier-labs/flow/issues/332

- [ ] Add `givenBalanceNotZero` modifier in `testFuzz_DepletionTimeOf` after decision on https://github.com/sablier-labs/flow/pull/334.