### PR TITLE
test: payable batch

### DIFF
--- a/tests/integration/concrete/payable/payable.t.sol
+++ b/tests/integration/concrete/payable/payable.t.sol
@@ -20,6 +20,11 @@ contract Payable_Integration_Concrete_Test is Shared_Integration_Concrete_Test {
         flow.adjustRatePerSecond{ value: FEE }(defaultStreamId, ud21x18(RATE_PER_SECOND_U128 + 1));
     }
 
+    function test_BatchWhenETHValueNotZero() external {
+        bytes[] memory calls = new bytes[](0);
+        flow.batch{ value: FEE }(calls);
+    }
+
     function test_CreateWhenETHValueNotZero() external {
         flow.create{ value: FEE }(users.sender, users.recipient, RATE_PER_SECOND, usdc, TRANSFERABLE);
     }

--- a/tests/integration/concrete/payable/payable.tree
+++ b/tests/integration/concrete/payable/payable.tree
@@ -2,6 +2,10 @@ Payable_Integration_Concrete_Test::adjustRatePerSecond
 └── when ETH value not zero
    └── it should make the call
 
+Payable_Integration_Concrete_Test::batch
+└── when ETH value not zero
+   └── it should make the call
+
 Payable_Integration_Concrete_Test::create
 └── when ETH value not zero
    └── it should make the call


### PR DESCRIPTION
I noticed that the `batch` function wasn't covered in https://github.com/sablier-labs/flow/pull/348.