### PR TITLE
test: refactor withdraw tests to cover all edge cases

### DIFF
--- a/benchmark/Flow.Gas.t.sol
+++ b/benchmark/Flow.Gas.t.sol
@@ -24,7 +24,7 @@ contract Flow_Gas_Test is Shared_Integration_Concrete_Test {
     function setUp() public override {
         Shared_Integration_Concrete_Test.setUp();
 
-        // Setup a few streams with usdc.
+        // Setup a few streams with USDC.
         for (uint8 count; count < 100; ++count) {
             depositDefaultAmount({ streamId: createDefaultStream() });
         }

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -62,18 +62,15 @@ abstract contract Integration_Test is Base_Test {
         deposit(streamId, depositAmount);
     }
 
-    /// @dev Update the snapshot using `adjustRatePerSecond` and then warp block timestamp to it.
-    function updateSnapshotTimeAndWarp(uint256 streamId) internal {
+    /// @dev Take the snapshot using `adjustRatePerSecond`.
+    function takeSnapshot(uint256 streamId) internal {
         resetPrank(users.sender);
         UD21x18 ratePerSecond = flow.getRatePerSecond(streamId);
 
-        // Updates the snapshot time via `adjustRatePerSecond`.
+        // Take the snapshot via `adjustRatePerSecond`.
         flow.adjustRatePerSecond(streamId, ud21x18(1));
 
         // Restores the rate per second.
         flow.adjustRatePerSecond(streamId, ratePerSecond);
-
-        // Warp to the snapshot time.
-        vm.warp({ newTimestamp: flow.getSnapshotTime(streamId) });
     }
 }

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -64,6 +64,10 @@ abstract contract Integration_Test is Base_Test {
 
     /// @dev Updates the snapshot time and snapshot debt by temporarily adjusting the rate per second..
     function updateSnapshot(uint256 streamId) internal {
+        // Read the current caller.
+        (, address originalCaller,) = vm.readCallers();
+
+        // Switch to the sender and adjust the rate per second.
         resetPrank(users.sender);
         UD21x18 ratePerSecond = flow.getRatePerSecond(streamId);
 
@@ -72,5 +76,8 @@ abstract contract Integration_Test is Base_Test {
 
         // Restore the original rate per second.
         flow.adjustRatePerSecond(streamId, ratePerSecond);
+
+        // Switch back to the original caller.
+        resetPrank(originalCaller);
     }
 }

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -62,15 +62,15 @@ abstract contract Integration_Test is Base_Test {
         deposit(streamId, depositAmount);
     }
 
-    /// @dev Take the snapshot using `adjustRatePerSecond`.
-    function takeSnapshot(uint256 streamId) internal {
+    /// @dev Updates the snapshot time and snapshot debt by temporarily adjusting the rate per second..
+    function updateSnapshot(uint256 streamId) internal {
         resetPrank(users.sender);
         UD21x18 ratePerSecond = flow.getRatePerSecond(streamId);
 
-        // Take the snapshot via `adjustRatePerSecond`.
+        // Take the snapshot by temporarily setting the rate per second to 1.
         flow.adjustRatePerSecond(streamId, ud21x18(1));
 
-        // Restores the rate per second.
+        // Restore the original rate per second.
         flow.adjustRatePerSecond(streamId, ratePerSecond);
     }
 }

--- a/tests/integration/concrete/Concrete.t.sol
+++ b/tests/integration/concrete/Concrete.t.sol
@@ -36,7 +36,7 @@ abstract contract Shared_Integration_Concrete_Test is Integration_Test {
         defaultStreamId = createDefaultStream();
 
         // Simulate one month of streaming.
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: ONE_MONTH_SINCE_START });
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/tests/integration/concrete/collect-protocol-revenue/collectProtocolRevenue.t.sol
+++ b/tests/integration/concrete/collect-protocol-revenue/collectProtocolRevenue.t.sol
@@ -21,7 +21,7 @@ contract CollectProtocolRevenue_Integration_Concrete_Test is Shared_Integration_
         depositDefaultAmount(streamIdWithProtocolFee);
 
         // Simulate one month of streaming.
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: ONE_MONTH_SINCE_START });
     }
 
     function test_RevertWhen_CallerNotAdmin() external {

--- a/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
+++ b/tests/integration/concrete/depletion-time-of/depletionTimeOf.t.sol
@@ -48,7 +48,7 @@ contract DepletionTimeOf_Integration_Concrete_Test is Shared_Integration_Concret
 
         // It should return the time at which the total debt exceeds the balance.
         uint40 actualDepletionTime = uint40(flow.depletionTimeOf(streamId));
-        uint40 exptectedDepletionTime = WARP_ONE_MONTH + uint40(solvencyPeriod + 1);
+        uint40 exptectedDepletionTime = ONE_MONTH_SINCE_START + uint40(solvencyPeriod + 1);
         assertEq(actualDepletionTime, exptectedDepletionTime, "depletion time");
     }
 

--- a/tests/integration/concrete/getters/getters.t.sol
+++ b/tests/integration/concrete/getters/getters.t.sol
@@ -83,7 +83,7 @@ contract Getters_Integration_Concrete_Test is Shared_Integration_Concrete_Test {
     }
 
     function test_GetSnapshotDebtScaledGivenNotZero() external givenNotNull {
-        vm.warp(WARP_ONE_MONTH);
+        vm.warp(ONE_MONTH_SINCE_START);
         flow.adjustRatePerSecond(defaultStreamId, ud21x18(1));
         assertEq(flow.getSnapshotDebtScaled(defaultStreamId), ONE_MONTH_DEBT_18D, "snapshot debt scaled");
     }

--- a/tests/integration/concrete/ongoing-debt-of/ongoingDebtScaledOf.t.sol
+++ b/tests/integration/concrete/ongoing-debt-of/ongoingDebtScaledOf.t.sol
@@ -18,8 +18,8 @@ contract OngoingDebtScaledOf_Integration_Concrete_Test is Shared_Integration_Con
     }
 
     function test_WhenSnapshotTimeInPresent() external givenNotNull givenNotPaused {
-        // Update the snapshot time and warp the current block timestamp to it.
-        updateSnapshotTimeAndWarp(defaultStreamId);
+        // Take snapshot.
+        takeSnapshot(defaultStreamId);
 
         // It should return zero.
         uint256 ongoingDebtScaled = flow.ongoingDebtScaledOf(defaultStreamId);

--- a/tests/integration/concrete/ongoing-debt-of/ongoingDebtScaledOf.t.sol
+++ b/tests/integration/concrete/ongoing-debt-of/ongoingDebtScaledOf.t.sol
@@ -19,7 +19,7 @@ contract OngoingDebtScaledOf_Integration_Concrete_Test is Shared_Integration_Con
 
     function test_WhenSnapshotTimeInPresent() external givenNotNull givenNotPaused {
         // Take snapshot.
-        takeSnapshot(defaultStreamId);
+        updateSnapshot(defaultStreamId);
 
         // It should return zero.
         uint256 ongoingDebtScaled = flow.ongoingDebtScaledOf(defaultStreamId);

--- a/tests/integration/concrete/payable/payable.t.sol
+++ b/tests/integration/concrete/payable/payable.t.sol
@@ -10,7 +10,7 @@ contract Payable_Integration_Concrete_Test is Shared_Integration_Concrete_Test {
         Shared_Integration_Concrete_Test.setUp();
         depositToDefaultStream();
 
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: ONE_MONTH_SINCE_START });
 
         // Make the sender the caller.
         resetPrank({ msgSender: users.sender });

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.22;
 
 import { IERC4906 } from "@openzeppelin/contracts/interfaces/IERC4906.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ud, ZERO } from "@prb/math/src/UD60x18.sol";
 
 import { ISablierFlow } from "src/interfaces/ISablierFlow.sol";
 import { Errors } from "src/libraries/Errors.sol";
@@ -13,28 +14,39 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
     function setUp() public override {
         Shared_Integration_Concrete_Test.setUp();
 
-        depositToDefaultStream();
+        // Deposit amount equals to one months of streaming.
+        deposit(defaultStreamId, ONE_MONTH_DEBT_6D);
+
+        // Take a snapshot after one month of streaming.
+        takeSnapshot(defaultStreamId);
+
+        // Forward time by one more month, so that total debt becomes (2 * ONE_MONTH_DEBT_6D).
+        vm.warp({ newTimestamp: getBlockTimestamp() + ONE_MONTH });
 
         // Set recipient as the caller for this test.
         resetPrank({ msgSender: users.recipient });
     }
 
     function test_RevertWhen_DelegateCall() external {
-        bytes memory callData = abi.encodeCall(flow.withdraw, (defaultStreamId, users.recipient, WITHDRAW_TIME));
+        // It should revert.
+        bytes memory callData = abi.encodeCall(flow.withdraw, (defaultStreamId, users.recipient, WITHDRAW_AMOUNT_6D));
         expectRevert_DelegateCall(callData);
     }
 
     function test_RevertGiven_Null() external whenNoDelegateCall {
-        bytes memory callData = abi.encodeCall(flow.withdraw, (nullStreamId, users.recipient, WITHDRAW_TIME));
+        // It should revert.
+        bytes memory callData = abi.encodeCall(flow.withdraw, (nullStreamId, users.recipient, WITHDRAW_AMOUNT_6D));
         expectRevert_Null(callData);
     }
 
     function test_RevertWhen_AmountZero() external whenNoDelegateCall givenNotNull {
+        // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_WithdrawAmountZero.selector, defaultStreamId));
         flow.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: 0 });
     }
 
     function test_RevertWhen_WithdrawalAddressZero() external whenNoDelegateCall givenNotNull whenAmountNotZero {
+        // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierFlow_WithdrawToZeroAddress.selector, defaultStreamId));
         flow.withdraw({ streamId: defaultStreamId, to: address(0), amount: WITHDRAW_AMOUNT_6D });
     }
@@ -49,6 +61,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
     {
         resetPrank({ msgSender: users.sender });
 
+        // It should revert.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierFlow_WithdrawalAddressNotRecipient.selector, defaultStreamId, users.sender, users.sender
@@ -67,6 +80,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
     {
         resetPrank({ msgSender: users.eve });
 
+        // It should revert.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierFlow_WithdrawalAddressNotRecipient.selector, defaultStreamId, users.eve, users.eve
@@ -85,98 +99,171 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
     {
         // It should withdraw.
         _test_Withdraw({
+            caller: users.recipient,
             streamId: defaultStreamId,
             to: users.eve,
-            depositAmount: DEPOSIT_AMOUNT_6D,
-            protocolFeeAmount: 0,
             withdrawAmount: WITHDRAW_AMOUNT_6D
         });
     }
 
-    function test_RevertGiven_StreamHasUncoveredDebt()
+    function test_WhenCallerNotRecipient()
         external
         whenNoDelegateCall
         givenNotNull
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenAmountOverdraws
     {
-        // Warp to the moment when stream accumulates uncovered debt.
-        vm.warp({ newTimestamp: uint40(flow.depletionTimeOf(defaultStreamId)) });
+        // Change caller to sender.
+        resetPrank({ msgSender: users.sender });
 
-        uint128 overdrawAmount = flow.getBalance(defaultStreamId) + 1;
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.SablierFlow_Overdraw.selector, defaultStreamId, overdrawAmount, overdrawAmount - 1
-            )
-        );
-        flow.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: overdrawAmount });
-    }
-
-    function test_RevertGiven_StreamHasNoUncoveredDebt()
-        external
-        whenNoDelegateCall
-        givenNotNull
-        whenAmountNotZero
-        whenWithdrawalAddressNotZero
-        whenWithdrawalAddressOwner
-        whenAmountOverdraws
-    {
-        uint128 overdrawAmount = flow.withdrawableAmountOf(defaultStreamId) + 1;
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.SablierFlow_Overdraw.selector, defaultStreamId, overdrawAmount, overdrawAmount - 1
-            )
-        );
-        flow.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: overdrawAmount });
-    }
-
-    function test_WhenAmountNotEqualTotalDebt()
-        external
-        whenNoDelegateCall
-        givenNotNull
-        whenAmountNotZero
-        whenWithdrawalAddressNotZero
-        whenWithdrawalAddressOwner
-        whenAmountNotOverdraw
-    {
-        // It should update snapshot debt
-        // It should make the withdrawal
+        // It should withdraw.
         _test_Withdraw({
+            caller: users.sender,
             streamId: defaultStreamId,
             to: users.recipient,
-            depositAmount: DEPOSIT_AMOUNT_6D,
-            protocolFeeAmount: 0,
-            withdrawAmount: uint128(flow.totalDebtOf(defaultStreamId)) - 1
+            withdrawAmount: WITHDRAW_AMOUNT_6D
         });
     }
 
-    function test_WhenAmountNotExceedSnapshotDebt()
+    function test_RevertWhen_AmountExceedsBalance()
         external
         whenNoDelegateCall
         givenNotNull
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenAmountNotOverdraw
+        whenCallerRecipient
+        givenBalanceNotExceedTotalDebt
     {
-        // It should not update snapshot time
-        // It should make the withdrawal
-        resetPrank({ msgSender: users.sender });
-        flow.pause(defaultStreamId);
+        // It should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierFlow_Overdraw.selector, defaultStreamId, ONE_MONTH_DEBT_6D + 1, ONE_MONTH_DEBT_6D
+            )
+        );
+        flow.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: ONE_MONTH_DEBT_6D + 1 });
+    }
 
-        vm.warp({ newTimestamp: getBlockTimestamp() + 1 });
+    function test_WhenAmountNotExceedBalance()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        whenAmountNotZero
+        whenWithdrawalAddressNotZero
+        whenWithdrawalAddressOwner
+        whenCallerRecipient
+        givenBalanceNotExceedTotalDebt
+    {
+        // It should withdraw.
+        _test_Withdraw({
+            caller: users.recipient,
+            streamId: defaultStreamId,
+            to: users.recipient,
+            withdrawAmount: WITHDRAW_AMOUNT_6D
+        });
+    }
 
-        resetPrank({ msgSender: users.recipient });
+    modifier givenBalanceExceedsTotalDebt() override {
+        // Deposit so that the stream has surplus balance.
+        deposit(defaultStreamId, DEPOSIT_AMOUNT_6D);
+        assert(flow.getBalance(defaultStreamId) > flow.totalDebtOf(defaultStreamId));
+        _;
+    }
+
+    function test_RevertWhen_AmountGreaterThanTotalDebt()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        whenAmountNotZero
+        whenWithdrawalAddressNotZero
+        whenWithdrawalAddressOwner
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+    {
+        uint128 totalDebt = 2 * ONE_MONTH_DEBT_6D;
+
+        // It should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.SablierFlow_Overdraw.selector, defaultStreamId, totalDebt + 1, totalDebt)
+        );
+        flow.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: totalDebt + 1 });
+    }
+
+    function test_WhenAmountEqualsTotalDebt()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        whenAmountNotZero
+        whenWithdrawalAddressNotZero
+        whenWithdrawalAddressOwner
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+    {
+        uint128 totalDebt = 2 * ONE_MONTH_DEBT_6D;
+
         // It should make the withdrawal.
         _test_Withdraw({
+            caller: users.recipient,
             streamId: defaultStreamId,
             to: users.recipient,
-            depositAmount: DEPOSIT_AMOUNT_6D,
-            protocolFeeAmount: 0,
-            withdrawAmount: WITHDRAW_AMOUNT_6D
+            withdrawAmount: totalDebt
         });
+
+        // It should update snapshot debt to zero.
+        assertEq(flow.getSnapshotDebtScaled(defaultStreamId), 0, "snapshot debt");
+        // It should update snapshot time to current time.
+        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START + ONE_MONTH, "snapshot time");
+    }
+
+    function test_WhenAmountLessThanSnapshotDebt()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        whenAmountNotZero
+        whenWithdrawalAddressNotZero
+        whenWithdrawalAddressOwner
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+        whenAmountLessThanTotalDebt
+    {
+        // It should make the withdrawal.
+        _test_Withdraw({
+            caller: users.recipient,
+            streamId: defaultStreamId,
+            to: users.recipient,
+            withdrawAmount: WITHDRAW_AMOUNT_6D // < snapshot debt
+         });
+
+        // It should reduce snapshot debt by amount withdrawn.
+        assertEq(flow.getSnapshotDebtScaled(defaultStreamId), ONE_MONTH_DEBT_18D - WITHDRAW_AMOUNT_18D, "snapshot debt");
+        // It should not update snapshot time.
+        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START, "snapshot debt");
+    }
+
+    function test_WhenAmountEqualsSnapshotDebt()
+        external
+        whenNoDelegateCall
+        givenNotNull
+        whenAmountNotZero
+        whenWithdrawalAddressNotZero
+        whenWithdrawalAddressOwner
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+        whenAmountLessThanTotalDebt
+    {
+        // It should make the withdrawal.
+        _test_Withdraw({
+            caller: users.recipient,
+            streamId: defaultStreamId,
+            to: users.recipient,
+            withdrawAmount: ONE_MONTH_DEBT_6D // = snapshot debt
+         });
+
+        // It should update snapshot debt to zero.
+        assertEq(flow.getSnapshotDebtScaled(defaultStreamId), 0, "snapshot debt");
+        // It should not update snapshot time.
+        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START, "snapshot debt");
     }
 
     function test_GivenProtocolFeeNotZero()
@@ -186,32 +273,37 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenAmountNotOverdraw
-        whenAmountEqualTotalDebt
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+        whenAmountLessThanTotalDebt
+        whenAmountGreaterThanSnapshotDebt
     {
-        // Go back to the starting point.
-        vm.warp({ newTimestamp: OCT_1_2024 });
+        // Turn on the protocol fee for usdc.
+        resetPrank(users.admin);
+        flow.setProtocolFee(usdc, PROTOCOL_FEE);
 
-        resetPrank({ msgSender: users.sender });
+        // Switch back to recipient.
+        resetPrank(users.recipient);
 
-        // Create the stream and make a deposit.
-        uint256 streamId = createDefaultStream(tokenWithProtocolFee);
-        deposit(streamId, DEPOSIT_AMOUNT_6D);
+        uint128 totalDebt = 2 * ONE_MONTH_DEBT_6D;
+        uint128 amountToWithdraw = ONE_MONTH_DEBT_6D + WITHDRAW_AMOUNT_6D; // < total debt and > snapshot debt
 
-        // Simulate the one month of streaming.
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
-
-        // Make recipient the caller test.
-        resetPrank({ msgSender: users.recipient });
-
-        // It should make the withdrawal.
+        // It should withdraw the net amount.
         _test_Withdraw({
-            streamId: streamId,
+            caller: users.recipient,
+            streamId: defaultStreamId,
             to: users.recipient,
-            depositAmount: DEPOSIT_AMOUNT_6D,
-            protocolFeeAmount: PROTOCOL_FEE_AMOUNT_6D,
-            withdrawAmount: WITHDRAW_AMOUNT_6D
+            withdrawAmount: amountToWithdraw
         });
+
+        // It should set snapshot debt to difference between total debt and amount withdrawn.
+        assertEq(
+            flow.getSnapshotDebtScaled(defaultStreamId),
+            getScaledAmount(totalDebt - amountToWithdraw, 6),
+            "snapshot debt"
+        );
+        // It should update snapshot time to current time
+        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot debt");
     }
 
     function test_GivenTokenHas18Decimals()
@@ -220,8 +312,11 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         givenNotNull
         whenAmountNotZero
         whenWithdrawalAddressNotZero
-        whenWithdrawalAddressNotOwner
-        whenAmountEqualTotalDebt
+        whenWithdrawalAddressOwner
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+        whenAmountLessThanTotalDebt
+        whenAmountGreaterThanSnapshotDebt
         givenProtocolFeeZero
     {
         // Go back to the starting point.
@@ -232,16 +327,20 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         deposit(streamId, DEPOSIT_AMOUNT_18D);
 
         // Simulate the one month of streaming.
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: ONE_MONTH_SINCE_START });
 
-        // It should withdraw the total debt.
+        // It should make the withdrawal.
         _test_Withdraw({
+            caller: users.recipient,
             streamId: streamId,
             to: users.recipient,
-            depositAmount: DEPOSIT_AMOUNT_18D,
-            protocolFeeAmount: 0,
-            withdrawAmount: WITHDRAW_AMOUNT_18D
-        });
+            withdrawAmount: WITHDRAW_AMOUNT_18D // < total debt and > snapshot debt
+         });
+
+        // It should set snapshot debt to difference between total debt and amount withdrawn.
+        assertEq(flow.getSnapshotDebtScaled(streamId), ONE_MONTH_DEBT_18D - WITHDRAW_AMOUNT_18D, "snapshot debt");
+        // It should update snapshot time to current time
+        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot debt");
     }
 
     function test_GivenTokenNotHave18Decimals()
@@ -251,87 +350,88 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenAmountEqualTotalDebt
+        whenCallerRecipient
+        givenBalanceExceedsTotalDebt
+        whenAmountLessThanTotalDebt
+        whenAmountGreaterThanSnapshotDebt
         givenProtocolFeeZero
     {
-        // It should withdraw the total debt.
+        uint128 totalDebt = 2 * ONE_MONTH_DEBT_6D;
+        uint128 amountToWithdraw = ONE_MONTH_DEBT_6D + WITHDRAW_AMOUNT_6D; // < total debt and > snapshot debt
+
+        // It should make the withdrawal.
         _test_Withdraw({
+            caller: users.recipient,
             streamId: defaultStreamId,
             to: users.recipient,
-            depositAmount: DEPOSIT_AMOUNT_6D,
-            protocolFeeAmount: 0,
-            withdrawAmount: WITHDRAW_AMOUNT_6D
+            withdrawAmount: amountToWithdraw
         });
+
+        // It should set snapshot debt to difference between total debt and amount withdrawn.
+        assertEq(
+            flow.getSnapshotDebtScaled(defaultStreamId),
+            getScaledAmount(totalDebt - amountToWithdraw, 6),
+            "snapshot debt"
+        );
+        // It should update snapshot time to current time
+        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot debt");
     }
 
-    function _test_Withdraw(
-        uint256 streamId,
-        address to,
-        uint128 depositAmount,
-        uint128 protocolFeeAmount,
-        uint128 withdrawAmount
-    )
-        private
-    {
+    function _test_Withdraw(address caller, uint256 streamId, address to, uint128 withdrawAmount) private {
         vars.token = flow.getToken(streamId);
-        vars.previousSnapshotTime = flow.getSnapshotTime(streamId);
-        vars.previousTotalDebt = flow.totalDebtOf(streamId);
+        vars.previousTokenBalance = vars.token.balanceOf(address(flow));
         vars.previousAggregateAmount = flow.aggregateBalance(vars.token);
-
-        vars.expectedProtocolRevenue = flow.protocolRevenue(vars.token) + protocolFeeAmount;
+        vars.previousStreamBalance = flow.getBalance(streamId);
+        vars.previousTotalDebt = flow.totalDebtOf(streamId);
+        if (flow.protocolFee(vars.token) > ZERO) {
+            vars.expectedProtocolFeeAmount = ud(withdrawAmount).mul(PROTOCOL_FEE).intoUint128();
+        }
+        vars.expectedProtocolRevenue = flow.protocolRevenue(vars.token) + vars.expectedProtocolFeeAmount;
+        vars.expectedWithdrawAmount = withdrawAmount - vars.expectedProtocolFeeAmount;
 
         // It should emit 1 {Transfer}, 1 {WithdrawFromFlowStream} and 1 {MetadataUpdated} events.
         vm.expectEmit({ emitter: address(vars.token) });
-        emit IERC20.Transfer({ from: address(flow), to: to, value: withdrawAmount - protocolFeeAmount });
+        emit IERC20.Transfer({ from: address(flow), to: to, value: vars.expectedWithdrawAmount });
 
-        vm.expectEmit({ emitter: address(flow) });
+        // vm.expectEmit({ emitter: address(flow) });
         emit ISablierFlow.WithdrawFromFlowStream({
             streamId: streamId,
             to: to,
             token: vars.token,
-            caller: users.recipient,
-            protocolFeeAmount: protocolFeeAmount,
-            withdrawAmount: withdrawAmount - protocolFeeAmount
+            caller: caller,
+            protocolFeeAmount: vars.expectedProtocolFeeAmount,
+            withdrawAmount: vars.expectedWithdrawAmount
         });
 
-        vm.expectEmit({ emitter: address(flow) });
+        // vm.expectEmit({ emitter: address(flow) });
         emit IERC4906.MetadataUpdate({ _tokenId: streamId });
-
-        // It should perform the ERC-20 transfer.
-        expectCallToTransfer({ token: vars.token, to: to, amount: withdrawAmount - protocolFeeAmount });
-
-        vars.previousTokenBalance = vars.token.balanceOf(address(flow));
 
         (vars.actualWithdrawnAmount, vars.actualProtocolFeeAmount) =
             flow.withdraw({ streamId: streamId, to: to, amount: withdrawAmount });
 
         // Check the returned values.
-        assertEq(vars.actualProtocolFeeAmount, protocolFeeAmount, "protocol fee amount");
-        assertEq(vars.actualWithdrawnAmount, withdrawAmount - protocolFeeAmount, "withdrawn amount");
+        assertEq(vars.actualProtocolFeeAmount, vars.expectedProtocolFeeAmount, "protocol fee amount");
+        assertEq(vars.actualWithdrawnAmount, vars.expectedWithdrawAmount, "withdrawn amount");
 
         // Assert the protocol revenue.
         assertEq(flow.protocolRevenue(vars.token), vars.expectedProtocolRevenue, "protocol revenue");
 
-        // It should update snapshot time.
-        vars.expectedSnapshotTime = flow.isPaused(streamId) ? vars.previousSnapshotTime : getBlockTimestamp();
-        assertEq(flow.getSnapshotTime(streamId), vars.expectedSnapshotTime, "snapshot time");
-
-        // It should decrease the total debt by the withdrawn value and fee amount.
+        // It should decrease the total debt by the withdrawn amount requested.
         vars.expectedTotalDebt = vars.previousTotalDebt - withdrawAmount;
         assertEq(flow.totalDebtOf(streamId), vars.expectedTotalDebt, "total debt");
 
-        // It should reduce the stream balance by the withdrawn value and fee amount.
-        vars.expectedStreamBalance = depositAmount - withdrawAmount;
+        // It should reduce the stream balance by the withdrawn amount requested.
+        vars.expectedStreamBalance = vars.previousStreamBalance - withdrawAmount;
         assertEq(flow.getBalance(streamId), vars.expectedStreamBalance, "stream balance");
 
         // It should reduce the token balance of stream.
-        vars.expectedTokenBalance = vars.previousTokenBalance - vars.actualWithdrawnAmount;
+        vars.expectedTokenBalance = vars.previousTokenBalance - vars.expectedWithdrawAmount;
         assertEq(vars.token.balanceOf(address(flow)), vars.expectedTokenBalance, "token balance");
 
-        // It should decrease the aggregate amount.
+        // It should reduce the aggregate amount by the withdrawn amount.
         assertEq(
             flow.aggregateBalance(vars.token),
-            vars.previousAggregateAmount - vars.actualWithdrawnAmount,
+            vars.previousAggregateAmount - vars.expectedWithdrawAmount,
             "aggregate amount"
         );
     }

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -18,7 +18,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         deposit(defaultStreamId, ONE_MONTH_DEBT_6D);
 
         // Take a snapshot after one month of streaming.
-        takeSnapshot(defaultStreamId);
+        updateSnapshot(defaultStreamId);
 
         // Forward time by one more month, so that total debt becomes (2 * ONE_MONTH_DEBT_6D).
         vm.warp({ newTimestamp: getBlockTimestamp() + ONE_MONTH });
@@ -89,22 +89,19 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         flow.withdraw({ streamId: defaultStreamId, to: users.eve, amount: WITHDRAW_AMOUNT_6D });
     }
 
-    function test_WhenCallerNotRecipient()
+    function test_WhenCallerRecipient()
         external
         whenNoDelegateCall
         givenNotNull
         whenAmountNotZero
         whenWithdrawalAddressNotZero
-        whenWithdrawalAddressOwner
+        whenWithdrawalAddressNotOwner
     {
-        // Change caller to sender.
-        resetPrank({ msgSender: users.sender });
-
         // It should withdraw.
         _test_Withdraw({
-            caller: users.sender,
+            caller: users.recipient,
             streamId: defaultStreamId,
-            to: users.recipient,
+            to: users.eve,
             withdrawAmount: WITHDRAW_AMOUNT_6D
         });
     }
@@ -116,7 +113,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceNotExceedTotalDebt
     {
         // It should revert.
@@ -135,7 +131,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceNotExceedTotalDebt
     {
         // It should withdraw.
@@ -161,7 +156,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
     {
         uint128 totalDebt = 2 * ONE_MONTH_DEBT_6D;
@@ -180,7 +174,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
     {
         uint128 totalDebt = 2 * ONE_MONTH_DEBT_6D;
@@ -206,7 +199,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
         whenAmountLessThanTotalDebt
     {
@@ -231,7 +223,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
         whenAmountLessThanTotalDebt
     {
@@ -256,12 +247,11 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
         whenAmountLessThanTotalDebt
         whenAmountGreaterThanSnapshotDebt
     {
-        // Turn on the protocol fee for usdc.
+        // Turn on the protocol fee for USDC.
         resetPrank(users.admin);
         flow.setProtocolFee(usdc, PROTOCOL_FEE);
 
@@ -296,7 +286,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
         whenAmountLessThanTotalDebt
         whenAmountGreaterThanSnapshotDebt
@@ -333,7 +322,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         whenAmountNotZero
         whenWithdrawalAddressNotZero
         whenWithdrawalAddressOwner
-        whenCallerRecipient
         givenBalanceExceedsTotalDebt
         whenAmountLessThanTotalDebt
         whenAmountGreaterThanSnapshotDebt

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -221,7 +221,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         // It should reduce snapshot debt by amount withdrawn.
         assertEq(flow.getSnapshotDebtScaled(defaultStreamId), ONE_MONTH_DEBT_18D - WITHDRAW_AMOUNT_18D, "snapshot debt");
         // It should not update snapshot time.
-        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START, "snapshot debt");
+        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START, "snapshot time");
     }
 
     function test_WhenAmountEqualsSnapshotDebt()
@@ -246,7 +246,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         // It should update snapshot debt to zero.
         assertEq(flow.getSnapshotDebtScaled(defaultStreamId), 0, "snapshot debt");
         // It should not update snapshot time.
-        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START, "snapshot debt");
+        assertEq(flow.getSnapshotTime(defaultStreamId), ONE_MONTH_SINCE_START, "snapshot time");
     }
 
     function test_GivenProtocolFeeNotZero()
@@ -286,7 +286,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
             "snapshot debt"
         );
         // It should update snapshot time to current time
-        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot debt");
+        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot time");
     }
 
     function test_GivenTokenHas18Decimals()
@@ -323,7 +323,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         // It should set snapshot debt to difference between total debt and amount withdrawn.
         assertEq(flow.getSnapshotDebtScaled(streamId), ONE_MONTH_DEBT_18D - WITHDRAW_AMOUNT_18D, "snapshot debt");
         // It should update snapshot time to current time
-        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot debt");
+        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot time");
     }
 
     function test_GivenTokenNotHave18Decimals()
@@ -357,7 +357,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
             "snapshot debt"
         );
         // It should update snapshot time to current time
-        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot debt");
+        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot time");
     }
 
     function _test_Withdraw(address caller, uint256 streamId, address to, uint128 withdrawAmount) private {
@@ -376,7 +376,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         vm.expectEmit({ emitter: address(vars.token) });
         emit IERC20.Transfer({ from: address(flow), to: to, value: vars.expectedWithdrawAmount });
 
-        // vm.expectEmit({ emitter: address(flow) });
+        vm.expectEmit({ emitter: address(flow) });
         emit ISablierFlow.WithdrawFromFlowStream({
             streamId: streamId,
             to: to,
@@ -386,7 +386,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
             withdrawAmount: vars.expectedWithdrawAmount
         });
 
-        // vm.expectEmit({ emitter: address(flow) });
+        vm.expectEmit({ emitter: address(flow) });
         emit IERC4906.MetadataUpdate({ _tokenId: streamId });
 
         (vars.actualWithdrawnAmount, vars.actualProtocolFeeAmount) =

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -89,23 +89,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         flow.withdraw({ streamId: defaultStreamId, to: users.eve, amount: WITHDRAW_AMOUNT_6D });
     }
 
-    function test_WhenCallerRecipient()
-        external
-        whenNoDelegateCall
-        givenNotNull
-        whenAmountNotZero
-        whenWithdrawalAddressNotZero
-        whenWithdrawalAddressNotOwner
-    {
-        // It should withdraw.
-        _test_Withdraw({
-            caller: users.recipient,
-            streamId: defaultStreamId,
-            to: users.eve,
-            withdrawAmount: WITHDRAW_AMOUNT_6D
-        });
-    }
-
     function test_WhenCallerNotRecipient()
         external
         whenNoDelegateCall

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -215,6 +215,8 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         uint256 initialSnapshotDebt = flow.getSnapshotDebtScaled(defaultStreamId);
         uint40 initialSnapshotTime = flow.getSnapshotTime(defaultStreamId);
 
+        assertTrue(WITHDRAW_AMOUNT_18D < initialSnapshotDebt, "amount < total debt");
+
         // It should make the withdrawal.
         _test_Withdraw({
             streamId: defaultStreamId,
@@ -241,9 +243,11 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         givenBalanceExceedsTotalDebt
         whenAmountLessThanTotalDebt
     {
-        uint256 snapshotDebt = getDescaledAmount(flow.getSnapshotDebtScaled(defaultStreamId), 6);
-        uint128 withdrawAmount = uint128(snapshotDebt); // amount = snapshot debt
+        uint256 initialSnapshotDebt = getDescaledAmount(flow.getSnapshotDebtScaled(defaultStreamId), 6);
         uint40 initialSnapshotTime = flow.getSnapshotTime(defaultStreamId);
+        uint128 withdrawAmount = uint128(initialSnapshotDebt); // amount = snapshot debt
+
+        assertTrue(withdrawAmount < flow.totalDebtOf(defaultStreamId), "amount < total debt");
 
         // It should make the withdrawal.
         _test_Withdraw({ streamId: defaultStreamId, to: users.recipient, withdrawAmount: withdrawAmount });
@@ -276,8 +280,10 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         resetPrank(originalCaller);
 
         uint256 initialSnapshotDebt = getDescaledAmount(flow.getSnapshotDebtScaled(defaultStreamId), 6);
-        uint128 withdrawAmount = uint128(initialSnapshotDebt) + WITHDRAW_AMOUNT_6D; // amount > snapshot debt
         uint256 initalTotalDebt = flow.totalDebtOf(defaultStreamId);
+        uint128 withdrawAmount = uint128(initialSnapshotDebt) + WITHDRAW_AMOUNT_6D; // amount > snapshot debt
+
+        assertTrue(withdrawAmount < initalTotalDebt, "amount < total debt");
 
         // It should withdraw the net amount.
         _test_Withdraw({ streamId: defaultStreamId, to: users.recipient, withdrawAmount: withdrawAmount });
@@ -319,7 +325,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         _test_Withdraw({
             streamId: streamId,
             to: users.recipient,
-            withdrawAmount: WITHDRAW_AMOUNT_18D // < total debt and > snapshot debt
+            withdrawAmount: WITHDRAW_AMOUNT_18D // withdrawAmount < total debt and > snapshot debt
          });
 
         // It should set snapshot debt to difference between total debt and amount withdrawn.
@@ -342,8 +348,10 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         givenProtocolFeeZero
     {
         uint256 initialSnapshotDebt = getDescaledAmount(flow.getSnapshotDebtScaled(defaultStreamId), 6);
-        uint128 withdrawAmount = uint128(initialSnapshotDebt) + WITHDRAW_AMOUNT_6D; // amount > snapshot debt
         uint256 initalTotalDebt = flow.totalDebtOf(defaultStreamId);
+        uint128 withdrawAmount = uint128(initialSnapshotDebt) + WITHDRAW_AMOUNT_6D; // amount > snapshot debt
+
+        assertTrue(withdrawAmount < flow.totalDebtOf(defaultStreamId), "amount < total debt");
 
         // It should make the withdrawal.
         _test_Withdraw({ streamId: defaultStreamId, to: users.recipient, withdrawAmount: withdrawAmount });
@@ -359,8 +367,6 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
     }
 
     function _test_Withdraw(uint256 streamId, address to, uint128 withdrawAmount) private {
-        assertTrue(withdrawAmount <= flow.totalDebtOf(streamId), "amount <= total debt");
-
         vars.token = flow.getToken(streamId);
         vars.previousTokenBalance = vars.token.balanceOf(address(flow));
         vars.previousAggregateAmount = flow.aggregateBalance(vars.token);

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -312,7 +312,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         // It should set snapshot debt to difference between total debt and amount withdrawn.
         assertEq(flow.getSnapshotDebtScaled(streamId), ONE_MONTH_DEBT_18D - WITHDRAW_AMOUNT_18D, "snapshot debt");
         // It should update snapshot time to current time
-        assertEq(flow.getSnapshotTime(defaultStreamId), getBlockTimestamp(), "snapshot time");
+        assertEq(flow.getSnapshotTime(streamId), getBlockTimestamp(), "snapshot time");
     }
 
     function test_GivenTokenNotHave18Decimals()

--- a/tests/integration/concrete/withdraw/withdraw.t.sol
+++ b/tests/integration/concrete/withdraw/withdraw.t.sol
@@ -351,7 +351,7 @@ contract Withdraw_Integration_Concrete_Test is Shared_Integration_Concrete_Test 
         uint256 initalTotalDebt = flow.totalDebtOf(defaultStreamId);
         uint128 withdrawAmount = uint128(initialSnapshotDebt) + WITHDRAW_AMOUNT_6D; // amount > snapshot debt
 
-        assertTrue(withdrawAmount < flow.totalDebtOf(defaultStreamId), "amount < total debt");
+        assertTrue(withdrawAmount < initalTotalDebt, "amount < total debt");
 
         // It should make the withdrawal.
         _test_Withdraw({ streamId: defaultStreamId, to: users.recipient, withdrawAmount: withdrawAmount });

--- a/tests/integration/concrete/withdraw/withdraw.tree
+++ b/tests/integration/concrete/withdraw/withdraw.tree
@@ -14,10 +14,8 @@ Withdraw_Integration_Concrete_Test
             ├── when withdrawal address not owner
             │  ├── when caller sender
             │  │  └── it should revert
-            │  ├── when caller unknown
-            │  │  └── it should revert
-            │  └── when caller recipient
-            │     └── it should withdraw
+            │  └── when caller unknown
+            │     └── it should revert
             └── when withdrawal address owner
                ├── when caller not recipient
                │  └── it should withdraw

--- a/tests/integration/concrete/withdraw/withdraw.tree
+++ b/tests/integration/concrete/withdraw/withdraw.tree
@@ -19,39 +19,40 @@ Withdraw_Integration_Concrete_Test
             │  └── when caller recipient
             │     └── it should withdraw
             └── when withdrawal address owner
-               ├── given balance not exceed total debt
-               │  ├── when amount exceeds balance
-               │  │  └── it should revert
-               │  └── when amount not exceed balance
-               │     └── it should withdraw
-               └── given balance exceeds total debt
-                  ├── when amount greater than total debt
-                  │  └── it should revert
-                  ├── when amount equals total debt
-                  │  ├── it should make the withdrawal
-                  │  ├── it should update snapshot debt to zero
-                  │  └── it should update snapshot time to current time
-                  └── when amount less than total debt
-                     ├── when amount less than snapshot debt
-                     │  ├── it should make the withdrawal
-                     │  ├── it should reduce snapshot debt by amount withdrawn
-                     │  └── it should not update snapshot time
-                     ├── when amount equals snapshot debt
+               └── when authorized caller
+                  ├── given balance not exceed total debt
+                  │  ├── when amount exceeds balance
+                  │  │  └── it should revert
+                  │  └── when amount not exceed balance
+                  │     └── it should withdraw
+                  └── given balance exceeds total debt
+                     ├── when amount greater than total debt
+                     │  └── it should revert
+                     ├── when amount equals total debt
                      │  ├── it should make the withdrawal
                      │  ├── it should update snapshot debt to zero
-                     │  └── it should not update snapshot time
-                     └── when amount greater than snapshot debt
-                        ├── given protocol fee not zero
-                        │  ├── it should update the protocol revenue
-                        │  └── it should withdraw the net amount
-                        └── given protocol fee zero
-                           ├── given token has 18 decimals
-                           │  └── it should make the withdrawal
-                           └── given token not have 18 decimals
-                              ├── it should make the withdrawal
-                              ├── it should reduce the stream balance by the withdrawn amount
-                              ├── it should reduce the aggregate amount by the withdrawn amount
-                              ├── it should set snapshot debt to difference between total debt and amount withdrawn
-                              ├── it should update snapshot time to current time
-                              ├── it should emit 1 {Transfer}, 1 {WithdrawFromFlowStream}  and 1 {MetadataUpdated} events
-                              └── it should return the withdrawn amount
+                     │  └── it should update snapshot time to current time
+                     └── when amount less than total debt
+                        ├── when amount less than snapshot debt
+                        │  ├── it should make the withdrawal
+                        │  ├── it should reduce snapshot debt by amount withdrawn
+                        │  └── it should not update snapshot time
+                        ├── when amount equals snapshot debt
+                        │  ├── it should make the withdrawal
+                        │  ├── it should update snapshot debt to zero
+                        │  └── it should not update snapshot time
+                        └── when amount greater than snapshot debt
+                           ├── given protocol fee not zero
+                           │  ├── it should update the protocol revenue
+                           │  └── it should withdraw the net amount
+                           └── given protocol fee zero
+                              ├── given token has 18 decimals
+                              │  └── it should make the withdrawal
+                              └── given token not have 18 decimals
+                                 ├── it should make the withdrawal
+                                 ├── it should reduce the stream balance by the withdrawn amount
+                                 ├── it should reduce the aggregate amount by the withdrawn amount
+                                 ├── it should set snapshot debt to difference between total debt and amount withdrawn
+                                 ├── it should update snapshot time to current time
+                                 ├── it should emit 1 {Transfer}, 1 {WithdrawFromFlowStream}  and 1 {MetadataUpdated} events
+                                 └── it should return the withdrawn amount

--- a/tests/integration/concrete/withdraw/withdraw.tree
+++ b/tests/integration/concrete/withdraw/withdraw.tree
@@ -19,31 +19,42 @@ Withdraw_Integration_Concrete_Test
             │  └── when caller recipient
             │     └── it should withdraw
             └── when withdrawal address owner
-               ├── when amount overdraws
-               │  ├── given stream has uncovered debt
-               │  │  └── it should revert
-               │  └── given stream has no uncovered debt
-               │     └── it should revert
-               └── when amount not overdraw
-                  ├── when amount not equal total debt
-                  │  ├── it should update snapshot debt
-                  │  └── it should make the withdrawal
-                  └── when amount equal total debt
-                     ├── when amount not exceed snapshot debt
-                     │   ├── it should not update snapshot time
-                     │   └── it should make the withdrawal
-                     └── when amount exceed snapshot debt
-                        ├── given protocol fee not zero
-                        │  ├── it should update the protocol revenue
-                        │  └── it should withdraw the net amount
-                        └── given protocol fee zero
-                           ├── given token has 18 decimals
-                           │  └── it should make the withdrawal
-                           └── given token not have 18 decimals
-                              ├── it should withdraw the withdrawable amount
-                              ├── it should reduce the stream balance by the withdrawn amount
-                              ├── it should reduce the aggregate amount by the withdrawn amount
-                              ├── it should update snapshot debt to zero
-                              ├── it should update snapshot time
-                              ├── it should emit 1 {Transfer}, 1 {WithdrawFromFlowStream}  and 1 {MetadataUpdated} events
-                              └── it should return the withdrawn amount
+               ├── when caller not recipient
+               │  └── it should withdraw
+               └── when caller recipient
+                  ├── given balance not exceed total debt
+                  │  ├── when amount exceeds balance
+                  │  │  └── it should revert
+                  │  └── when amount not exceed balance
+                  │     └── it should withdraw
+                  └── given balance exceeds total debt
+                     ├── when amount greater than total debt
+                     │  └── it should revert
+                     ├── when amount equals total debt
+                     │  ├── it should make the withdrawal
+                     │  ├── it should update snapshot debt to zero
+                     │  └── it should update snapshot time to current time
+                     └── when amount less than total debt
+                        ├── when amount less than snapshot debt
+                        │  ├── it should make the withdrawal
+                        │  ├── it should reduce snapshot debt by amount withdrawn
+                        │  └── it should not update snapshot time
+                        ├── when amount equals snapshot debt
+                        │  ├── it should make the withdrawal
+                        │  ├── it should update snapshot debt to zero
+                        │  └── it should not update snapshot time
+                        └── when amount greater than snapshot debt
+                           ├── given protocol fee not zero
+                           │  ├── it should update the protocol revenue
+                           │  └── it should withdraw the net amount
+                           └── given protocol fee zero
+                              ├── given token has 18 decimals
+                              │  └── it should make the withdrawal
+                              └── given token not have 18 decimals
+                                 ├── it should make the withdrawal
+                                 ├── it should reduce the stream balance by the withdrawn amount
+                                 ├── it should reduce the aggregate amount by the withdrawn amount
+                                 ├── it should set snapshot debt to difference between total debt and amount withdrawn
+                                 ├── it should update snapshot time to current time
+                                 ├── it should emit 1 {Transfer}, 1 {WithdrawFromFlowStream}  and 1 {MetadataUpdated} events
+                                 └── it should return the withdrawn amount

--- a/tests/integration/concrete/withdraw/withdraw.tree
+++ b/tests/integration/concrete/withdraw/withdraw.tree
@@ -14,45 +14,44 @@ Withdraw_Integration_Concrete_Test
             ├── when withdrawal address not owner
             │  ├── when caller sender
             │  │  └── it should revert
-            │  └── when caller unknown
-            │     └── it should revert
+            │  ├── when caller unknown
+            │  │  └── it should revert
+            │  └── when caller recipient
+            │     └── it should withdraw
             └── when withdrawal address owner
-               ├── when caller not recipient
-               │  └── it should withdraw
-               └── when caller recipient
-                  ├── given balance not exceed total debt
-                  │  ├── when amount exceeds balance
-                  │  │  └── it should revert
-                  │  └── when amount not exceed balance
-                  │     └── it should withdraw
-                  └── given balance exceeds total debt
-                     ├── when amount greater than total debt
-                     │  └── it should revert
-                     ├── when amount equals total debt
+               ├── given balance not exceed total debt
+               │  ├── when amount exceeds balance
+               │  │  └── it should revert
+               │  └── when amount not exceed balance
+               │     └── it should withdraw
+               └── given balance exceeds total debt
+                  ├── when amount greater than total debt
+                  │  └── it should revert
+                  ├── when amount equals total debt
+                  │  ├── it should make the withdrawal
+                  │  ├── it should update snapshot debt to zero
+                  │  └── it should update snapshot time to current time
+                  └── when amount less than total debt
+                     ├── when amount less than snapshot debt
+                     │  ├── it should make the withdrawal
+                     │  ├── it should reduce snapshot debt by amount withdrawn
+                     │  └── it should not update snapshot time
+                     ├── when amount equals snapshot debt
                      │  ├── it should make the withdrawal
                      │  ├── it should update snapshot debt to zero
-                     │  └── it should update snapshot time to current time
-                     └── when amount less than total debt
-                        ├── when amount less than snapshot debt
-                        │  ├── it should make the withdrawal
-                        │  ├── it should reduce snapshot debt by amount withdrawn
-                        │  └── it should not update snapshot time
-                        ├── when amount equals snapshot debt
-                        │  ├── it should make the withdrawal
-                        │  ├── it should update snapshot debt to zero
-                        │  └── it should not update snapshot time
-                        └── when amount greater than snapshot debt
-                           ├── given protocol fee not zero
-                           │  ├── it should update the protocol revenue
-                           │  └── it should withdraw the net amount
-                           └── given protocol fee zero
-                              ├── given token has 18 decimals
-                              │  └── it should make the withdrawal
-                              └── given token not have 18 decimals
-                                 ├── it should make the withdrawal
-                                 ├── it should reduce the stream balance by the withdrawn amount
-                                 ├── it should reduce the aggregate amount by the withdrawn amount
-                                 ├── it should set snapshot debt to difference between total debt and amount withdrawn
-                                 ├── it should update snapshot time to current time
-                                 ├── it should emit 1 {Transfer}, 1 {WithdrawFromFlowStream}  and 1 {MetadataUpdated} events
-                                 └── it should return the withdrawn amount
+                     │  └── it should not update snapshot time
+                     └── when amount greater than snapshot debt
+                        ├── given protocol fee not zero
+                        │  ├── it should update the protocol revenue
+                        │  └── it should withdraw the net amount
+                        └── given protocol fee zero
+                           ├── given token has 18 decimals
+                           │  └── it should make the withdrawal
+                           └── given token not have 18 decimals
+                              ├── it should make the withdrawal
+                              ├── it should reduce the stream balance by the withdrawn amount
+                              ├── it should reduce the aggregate amount by the withdrawn amount
+                              ├── it should set snapshot debt to difference between total debt and amount withdrawn
+                              ├── it should update snapshot time to current time
+                              ├── it should emit 1 {Transfer}, 1 {WithdrawFromFlowStream}  and 1 {MetadataUpdated} events
+                              └── it should return the withdrawn amount

--- a/tests/integration/concrete/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/tests/integration/concrete/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -9,7 +9,7 @@ contract WithdrawableAmountOf_Integration_Concrete_Test is Shared_Integration_Co
         depositToDefaultStream();
 
         // Simulate one month of streaming.
-        vm.warp({ newTimestamp: WARP_ONE_MONTH });
+        vm.warp({ newTimestamp: ONE_MONTH_SINCE_START });
 
         // It should return the correct withdrawable amount.
         uint128 withdrawableAmount = flow.withdrawableAmountOf(defaultStreamId);

--- a/tests/integration/fuzz/ongoingDebtScaledOf.t.sol
+++ b/tests/integration/fuzz/ongoingDebtScaledOf.t.sol
@@ -52,8 +52,8 @@ contract OngoingDebtScaledOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
         // Simulate the passage of time.
         vm.warp({ newTimestamp: getBlockTimestamp() + timeJump });
 
-        // Update the snapshot time and warp the current block timestamp to it.
-        updateSnapshotTimeAndWarp(streamId);
+        // Take snapshot.
+        takeSnapshot(streamId);
 
         // Assert that ongoing debt is zero.
         uint256 actualOngoingDebtScaled = flow.ongoingDebtScaledOf(streamId);
@@ -76,8 +76,8 @@ contract OngoingDebtScaledOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
     {
         (streamId, decimals,) = useFuzzedStreamOrCreate(streamId, decimals);
 
-        // Update the snapshot time and warp the current block timestamp to it.
-        updateSnapshotTimeAndWarp(streamId);
+        // Take snapshot.
+        takeSnapshot(streamId);
 
         // Bound the time jump to provide a realistic time frame.
         timeJump = boundUint40(timeJump, 0 seconds, 100 weeks);

--- a/tests/integration/fuzz/ongoingDebtScaledOf.t.sol
+++ b/tests/integration/fuzz/ongoingDebtScaledOf.t.sol
@@ -53,7 +53,7 @@ contract OngoingDebtScaledOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
         vm.warp({ newTimestamp: getBlockTimestamp() + timeJump });
 
         // Take snapshot.
-        takeSnapshot(streamId);
+        updateSnapshot(streamId);
 
         // Assert that ongoing debt is zero.
         uint256 actualOngoingDebtScaled = flow.ongoingDebtScaledOf(streamId);
@@ -77,7 +77,7 @@ contract OngoingDebtScaledOf_Integration_Fuzz_Test is Shared_Integration_Fuzz_Te
         (streamId, decimals,) = useFuzzedStreamOrCreate(streamId, decimals);
 
         // Take snapshot.
-        takeSnapshot(streamId);
+        updateSnapshot(streamId);
 
         // Bound the time jump to provide a realistic time frame.
         timeJump = boundUint40(timeJump, 0 seconds, 100 weeks);

--- a/tests/utils/Constants.sol
+++ b/tests/utils/Constants.sol
@@ -45,9 +45,9 @@ abstract contract Constants {
     // Time
     uint40 internal constant OCT_1_2024 = 1_727_740_800;
     uint40 internal constant ONE_MONTH = 30 days; // "30/360" convention
+    uint40 internal constant ONE_MONTH_SINCE_START = OCT_1_2024 + ONE_MONTH;
     // Solvency period is 49999999.999999 seconds.
     uint40 internal constant SOLVENCY_PERIOD = uint40(DEPOSIT_AMOUNT_18D / RATE_PER_SECOND_U128); // ~578 days
-    uint40 internal constant WARP_ONE_MONTH = OCT_1_2024 + ONE_MONTH;
     // The following variable represents the timestamp at which the stream depletes all its balance.
     uint40 internal constant WARP_SOLVENCY_PERIOD = OCT_1_2024 + SOLVENCY_PERIOD;
     uint40 internal constant WITHDRAW_TIME = OCT_1_2024 + 2_500_000;

--- a/tests/utils/Constants.sol
+++ b/tests/utils/Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { UD21x18 } from "@prb/math/src/UD21x18.sol";
-import { UD60x18 } from "@prb/math/src/UD60x18.sol";
+import { UD60x18, ud } from "@prb/math/src/UD60x18.sol";
 
 abstract contract Constants {
     // Amounts
@@ -14,8 +14,8 @@ abstract contract Constants {
     uint128 internal constant TOTAL_AMOUNT_WITH_BROKER_FEE_18D = DEPOSIT_AMOUNT_18D + BROKER_FEE_AMOUNT_18D;
     uint128 internal constant TOTAL_AMOUNT_WITH_BROKER_FEE_6D = DEPOSIT_AMOUNT_6D + BROKER_FEE_AMOUNT_6D;
     uint128 internal constant TRANSFER_VALUE = 50_000;
-    uint128 internal constant WITHDRAW_AMOUNT_18D = 2500e18;
-    uint128 internal constant WITHDRAW_AMOUNT_6D = 2500e6;
+    uint128 internal constant WITHDRAW_AMOUNT_18D = 500e18;
+    uint128 internal constant WITHDRAW_AMOUNT_6D = 500e6;
 
     // Fees
     UD60x18 internal constant BROKER_FEE = UD60x18.wrap(0.01e18); // 1%
@@ -23,8 +23,8 @@ abstract contract Constants {
     uint128 internal constant BROKER_FEE_AMOUNT_6D = 505.050505e6; // 1% of total amount
     UD60x18 internal constant MAX_FEE = UD60x18.wrap(0.1e18); // 10%
     UD60x18 internal constant PROTOCOL_FEE = UD60x18.wrap(0.01e18); // 1%
-    uint128 internal constant PROTOCOL_FEE_AMOUNT_18D = 25e18; // 1% of withdraw amount
-    uint128 internal constant PROTOCOL_FEE_AMOUNT_6D = 25e6; // 1% of withdraw amount
+    uint128 internal immutable PROTOCOL_FEE_AMOUNT_18D = ud(WITHDRAW_AMOUNT_18D).mul(PROTOCOL_FEE).intoUint128();
+    uint128 internal immutable PROTOCOL_FEE_AMOUNT_6D = ud(WITHDRAW_AMOUNT_6D).mul(PROTOCOL_FEE).intoUint128();
 
     // Max value
     uint128 internal constant UINT128_MAX = type(uint128).max;

--- a/tests/utils/Modifiers.sol
+++ b/tests/utils/Modifiers.sol
@@ -44,6 +44,11 @@ abstract contract Modifiers is Utils {
         _;
     }
 
+    modifier whenCallerRecipient() {
+        resetPrank({ msgSender: users.recipient });
+        _;
+    }
+
     modifier whenCallerSender() {
         _;
     }
@@ -152,11 +157,27 @@ abstract contract Modifiers is Utils {
                                       WITHDRAW
     //////////////////////////////////////////////////////////////////////////*/
 
+    modifier givenBalanceExceedsTotalDebt() virtual {
+        _;
+    }
+
+    modifier givenBalanceNotExceedTotalDebt() {
+        _;
+    }
+
     modifier givenProtocolFeeZero() {
         _;
     }
 
     modifier whenAmountEqualTotalDebt() {
+        _;
+    }
+
+    modifier whenAmountGreaterThanSnapshotDebt() {
+        _;
+    }
+
+    modifier whenAmountLessThanTotalDebt() {
         _;
     }
 

--- a/tests/utils/Modifiers.sol
+++ b/tests/utils/Modifiers.sol
@@ -169,10 +169,6 @@ abstract contract Modifiers is Utils {
         _;
     }
 
-    modifier whenAmountEqualTotalDebt() {
-        _;
-    }
-
     modifier whenAmountGreaterThanSnapshotDebt() {
         _;
     }
@@ -181,19 +177,7 @@ abstract contract Modifiers is Utils {
         _;
     }
 
-    modifier whenAmountNotOverdraw() {
-        _;
-    }
-
     modifier whenAmountNotZero() {
-        _;
-    }
-
-    modifier whenAmountOverdraws() {
-        _;
-    }
-
-    modifier whenWithdrawalAddressOwner() {
         _;
     }
 
@@ -202,6 +186,10 @@ abstract contract Modifiers is Utils {
     }
 
     modifier whenWithdrawalAddressNotZero() {
+        _;
+    }
+
+    modifier whenWithdrawalAddressOwner() {
         _;
     }
 }

--- a/tests/utils/Modifiers.sol
+++ b/tests/utils/Modifiers.sol
@@ -44,11 +44,6 @@ abstract contract Modifiers is Utils {
         _;
     }
 
-    modifier whenCallerRecipient() {
-        resetPrank({ msgSender: users.recipient });
-        _;
-    }
-
     modifier whenCallerSender() {
         _;
     }

--- a/tests/utils/Vars.sol
+++ b/tests/utils/Vars.sol
@@ -11,6 +11,7 @@ struct Vars {
     // previous values.
     uint256 previousAggregateAmount;
     uint256 previousOngoingDebtScaled;
+    uint256 previousSnapshotDebtScaled;
     uint40 previousSnapshotTime;
     uint128 previousStreamBalance;
     uint256 previousTokenBalance;

--- a/tests/utils/Vars.sol
+++ b/tests/utils/Vars.sol
@@ -11,7 +11,6 @@ struct Vars {
     // previous values.
     uint256 previousAggregateAmount;
     uint256 previousOngoingDebtScaled;
-    uint256 previousSnapshotDebtScaled;
     uint40 previousSnapshotTime;
     uint128 previousStreamBalance;
     uint256 previousTokenBalance;


### PR DESCRIPTION
### Changelog
- Closes https://github.com/sablier-labs/flow/issues/238.
- Renames `updateSnapshotTimeAndWarp` function to `takeSnapshot` and removes `warp` logic from it.
- Renames `WARP_ONE_MONTH` constant to `ONE_MONTH_SINCE_START`. 
    - The variable name `WARP_ONE_MONTH` goes well when called in `vm.warp` but not when used as a variable. For example in `uint40 exptectedDepletionTime = WARP_ONE_MONTH + uint40(solvencyPeriod + 1)`.