### PR TITLE
test: run fork tests without forking the chain during development

### DIFF
--- a/tests/fork/Flow.t.sol
+++ b/tests/fork/Flow.t.sol
@@ -12,7 +12,7 @@ import { Flow } from "src/types/DataTypes.sol";
 
 import { Fork_Test } from "./Fork.t.sol";
 
-contract Flow_Fork_Test is Fork_Test {
+abstract contract Flow_Fork_Test is Fork_Test {
     /// @dev Total number of streams to create for each token.
     uint256 internal constant TOTAL_STREAMS = 20;
 
@@ -42,12 +42,15 @@ contract Flow_Fork_Test is Fork_Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                                    CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    constructor(IERC20 forkToken) Fork_Test(forkToken) { }
+
+    /*//////////////////////////////////////////////////////////////////////////
                                     FORK TEST
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev For each token:
-    /// - It creates the equal number of new streams
-    /// - It executes the same sequence of flow functions for each token
     /// @param params The fuzzed parameters to use for the tests.
     /// @param flowFuncU8 Using calldata here as required by array slicing in Solidity, and using `uint8` to be
     /// able to bound it.
@@ -66,18 +69,15 @@ contract Flow_Fork_Test is Fork_Test {
             flowFunc[i] = FlowFunc(boundUint8(flowFuncU8[i], 0, 6));
         }
 
-        // Run the tests for each token.
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            token = IERC20(tokens[i]);
-            _executeSequence(params, flowFunc);
-        }
+        // Run the sequence of tests.
+        _executeSequence(params, flowFunc);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
                                 PRIVATE HELPERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev For a given token, it creates a number of streams and then execute the sequence of Flow functions.
+    /// @dev It creates a number of streams and then execute the sequence of Flow functions.
     /// @param params The fuzzed parameters to use for the tests.
     /// @param flowFunc The sequence of Flow functions to execute.
     function _executeSequence(Params memory params, FlowFunc[] memory flowFunc) private {
@@ -182,7 +182,7 @@ contract Flow_Fork_Test is Fork_Test {
         if (flow.isVoided(streamId)) {
             bool found = false;
             for (uint256 i = 1; i < flow.nextStreamId(); ++i) {
-                if (!flow.isVoided(i) && token == flow.getToken(i)) {
+                if (!flow.isVoided(i) && FORK_TOKEN == flow.getToken(i)) {
                     streamId = i;
                     found = true;
                     break;
@@ -196,7 +196,7 @@ contract Flow_Fork_Test is Fork_Test {
                     recipient: users.recipient,
                     ratePerSecond: RATE_PER_SECOND,
                     startTime: ZERO,
-                    token: token,
+                    token: FORK_TOKEN,
                     transferable: TRANSFERABLE
                 });
             }
@@ -291,7 +291,7 @@ contract Flow_Fork_Test is Fork_Test {
         vm.expectEmit({ emitter: address(flow) });
         emit ISablierFlow.CreateFlowStream({
             streamId: vars.expectedStreamId,
-            token: token,
+            token: FORK_TOKEN,
             sender: sender,
             recipient: recipient,
             ratePerSecond: ratePerSecond,
@@ -304,7 +304,7 @@ contract Flow_Fork_Test is Fork_Test {
             sender: sender,
             ratePerSecond: ratePerSecond,
             startTime: ZERO,
-            token: token,
+            token: FORK_TOKEN,
             transferable: transferable
         });
 
@@ -318,8 +318,8 @@ contract Flow_Fork_Test is Fork_Test {
             ratePerSecond: ratePerSecond,
             snapshotDebtScaled: 0,
             sender: sender,
-            token: token,
-            tokenDecimals: IERC20Metadata(address(token)).decimals()
+            token: FORK_TOKEN,
+            tokenDecimals: IERC20Metadata(address(FORK_TOKEN)).decimals()
         });
 
         // It should create the stream.
@@ -343,8 +343,8 @@ contract Flow_Fork_Test is Fork_Test {
         uint8 tokenDecimals = flow.getTokenDecimals(streamId);
 
         // Following variables are used during assertions.
-        uint256 initialAggregateAmount = flow.aggregateBalance(token);
-        uint256 initialTokenBalance = token.balanceOf(address(flow));
+        uint256 initialAggregateAmount = flow.aggregateBalance(FORK_TOKEN);
+        uint256 initialTokenBalance = FORK_TOKEN.balanceOf(address(flow));
         uint128 initialStreamBalance = flow.getBalance(streamId);
 
         depositAmount = boundDepositAmount(
@@ -353,11 +353,11 @@ contract Flow_Fork_Test is Fork_Test {
 
         address sender = flow.getSender(streamId);
         resetPrank({ msgSender: sender });
-        deal({ token: address(token), to: sender, give: depositAmount });
+        deal({ token: address(FORK_TOKEN), to: sender, give: depositAmount });
         safeApprove(depositAmount);
 
         // Expect the relevant events to be emitted.
-        vm.expectEmit({ emitter: address(token) });
+        vm.expectEmit({ emitter: address(FORK_TOKEN) });
         emit IERC20.Transfer({ from: sender, to: address(flow), value: depositAmount });
 
         vm.expectEmit({ emitter: address(flow) });
@@ -367,13 +367,13 @@ contract Flow_Fork_Test is Fork_Test {
         emit IERC4906.MetadataUpdate({ _tokenId: streamId });
 
         // It should perform the ERC-20 transfer.
-        expectCallToTransferFrom({ token: token, from: sender, to: address(flow), value: depositAmount });
+        expectCallToTransferFrom({ token: FORK_TOKEN, from: sender, to: address(flow), value: depositAmount });
 
         // Make the deposit.
         flow.deposit{ value: FEE }(streamId, depositAmount, sender, flow.getRecipient(streamId));
 
         // Assert that the token balance of stream has been updated.
-        vars.actualTokenBalance = token.balanceOf(address(flow));
+        vars.actualTokenBalance = FORK_TOKEN.balanceOf(address(flow));
         vars.expectedTokenBalance = initialTokenBalance + depositAmount;
         assertEq(vars.actualTokenBalance, vars.expectedTokenBalance, "Deposit: token balance");
 
@@ -383,7 +383,7 @@ contract Flow_Fork_Test is Fork_Test {
         assertEq(vars.actualStreamBalance, vars.expectedStreamBalance, "Deposit: stream balance");
 
         // Assert that aggregate amount has been updated.
-        vars.actualAggregateAmount = flow.aggregateBalance(token);
+        vars.actualAggregateAmount = flow.aggregateBalance(FORK_TOKEN);
         vars.expectedAggregateAmount = initialAggregateAmount + depositAmount;
         assertEq(vars.actualAggregateAmount, vars.expectedAggregateAmount, "Deposit: aggregate amount");
     }
@@ -441,12 +441,12 @@ contract Flow_Fork_Test is Fork_Test {
         // Bound the refund amount to avoid error.
         refundAmount = boundUint128(refundAmount, 1, flow.refundableAmountOf(streamId));
 
-        uint256 initialAggregateAmount = flow.aggregateBalance(token);
-        uint256 initialTokenBalance = token.balanceOf(address(flow));
+        uint256 initialAggregateAmount = flow.aggregateBalance(FORK_TOKEN);
+        uint256 initialTokenBalance = FORK_TOKEN.balanceOf(address(flow));
         uint128 initialStreamBalance = flow.getBalance(streamId);
 
         // Expect the relevant events to be emitted.
-        vm.expectEmit({ emitter: address(token) });
+        vm.expectEmit({ emitter: address(FORK_TOKEN) });
         emit IERC20.Transfer({ from: address(flow), to: sender, value: refundAmount });
 
         vm.expectEmit({ emitter: address(flow) });
@@ -459,7 +459,7 @@ contract Flow_Fork_Test is Fork_Test {
         flow.refund{ value: FEE }(streamId, refundAmount);
 
         // Assert that the token balance of stream has been updated.
-        vars.actualTokenBalance = token.balanceOf(address(flow));
+        vars.actualTokenBalance = FORK_TOKEN.balanceOf(address(flow));
         vars.expectedTokenBalance = initialTokenBalance - refundAmount;
         assertEq(vars.actualTokenBalance, vars.expectedTokenBalance, "Refund: token balance");
 
@@ -469,7 +469,7 @@ contract Flow_Fork_Test is Fork_Test {
         assertEq(vars.actualStreamBalance, vars.expectedStreamBalance, "Refund: stream balance");
 
         // Assert that aggregate amount has been updated.
-        vars.actualAggregateAmount = flow.aggregateBalance(token);
+        vars.actualAggregateAmount = flow.aggregateBalance(FORK_TOKEN);
         vars.expectedAggregateAmount = initialAggregateAmount - refundAmount;
         assertEq(vars.actualAggregateAmount, vars.expectedAggregateAmount, "Refund: aggregate amount");
     }
@@ -574,7 +574,7 @@ contract Flow_Fork_Test is Fork_Test {
             flow.withdrawableAmountOf(streamId)
         );
 
-        uint256 initialTokenBalance = token.balanceOf(address(flow));
+        uint256 initialTokenBalance = FORK_TOKEN.balanceOf(address(flow));
         uint256 totalDebt = flow.totalDebtOf(streamId);
 
         vars.expectedSnapshotTime = withdrawAmount
@@ -585,17 +585,17 @@ contract Flow_Fork_Test is Fork_Test {
         (, address caller,) = vm.readCallers();
         address recipient = flow.getRecipient(streamId);
 
-        vars.expectedAggregateAmount = flow.aggregateBalance(token) - withdrawAmount;
+        vars.expectedAggregateAmount = flow.aggregateBalance(FORK_TOKEN) - withdrawAmount;
 
         // Expect the relevant events to be emitted.
-        vm.expectEmit({ emitter: address(token) });
+        vm.expectEmit({ emitter: address(FORK_TOKEN) });
         emit IERC20.Transfer({ from: address(flow), to: recipient, value: withdrawAmount });
 
         vm.expectEmit({ emitter: address(flow) });
         emit ISablierFlow.WithdrawFromFlowStream({
             streamId: streamId,
             to: recipient,
-            token: token,
+            token: FORK_TOKEN,
             caller: caller,
             withdrawAmount: withdrawAmount
         });
@@ -621,12 +621,12 @@ contract Flow_Fork_Test is Fork_Test {
         assertEq(vars.actualStreamBalance, vars.expectedStreamBalance, "Withdraw: stream balance");
 
         // It should reduce the token balance of stream.
-        vars.actualTokenBalance = token.balanceOf(address(flow));
+        vars.actualTokenBalance = FORK_TOKEN.balanceOf(address(flow));
         vars.expectedTokenBalance = initialTokenBalance - withdrawAmount;
         assertEq(vars.actualTokenBalance, vars.expectedTokenBalance, "Withdraw: token balance");
 
         // It should reduce the aggregate amount by the withdrawn amount.
-        vars.actualAggregateAmount = flow.aggregateBalance(token);
+        vars.actualAggregateAmount = flow.aggregateBalance(FORK_TOKEN);
         assertEq(vars.actualAggregateAmount, vars.expectedAggregateAmount, "Withdraw: aggregate amount");
     }
 }

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -12,32 +12,14 @@ abstract contract Fork_Test is Base_Test {
                                   STATE VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev A typical 18-decimal ERC-20 token with a normal total supply.
-    IERC20 private constant DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    IERC20 internal immutable FORK_TOKEN;
 
-    /// @dev An ERC-20 token with 2 decimals.
-    IERC20 private constant EURS = IERC20(0xdB25f211AB05b1c97D595516F45794528a807ad8);
+    /*//////////////////////////////////////////////////////////////////////////
+                                    CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev An ERC-20 token with a large total supply.
-    IERC20 private constant SHIBA = IERC20(0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE);
-
-    /// @dev An ERC-20 token with 6 decimals.
-    IERC20 private constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
-
-    /// @dev An ERC-20 token that suffers from the missing return value bug.
-    IERC20 private constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
-
-    IERC20 internal token;
-
-    constructor() {
-        // Since we are using the real tokens in the fork tests, we need to remove the pre-deployed tokens from
-        // `CommonBase` and push the tokens addresses from mainnet.
-        delete tokens;
-        tokens.push(DAI);
-        tokens.push(EURS);
-        tokens.push(SHIBA);
-        tokens.push(USDC);
-        tokens.push(USDT);
+    constructor(IERC20 forkToken) {
+        FORK_TOKEN = forkToken;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -46,9 +28,8 @@ abstract contract Fork_Test is Base_Test {
 
     function setUp() public virtual override {
         // Fork Ethereum Mainnet at a block number after the Sablier deployment.
-        vm.createSelectFork({ blockNumber: 21_718_689, urlOrAlias: "mainnet" });
-
-        Base_Test.setUp();
+        // TODO: uncomment the following line after deployment.
+        // vm.createSelectFork({ blockNumber: 21_718_689, urlOrAlias: "mainnet" });
 
         // TODO: update the flow contract address once deployed.
         // Load mainnet address.
@@ -56,10 +37,12 @@ abstract contract Fork_Test is Base_Test {
         // Label the flow contract.
         // vm.label(address(flow), "Flow");
 
-        // Label the tokens.
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            vm.label({ account: address(tokens[i]), newLabel: IERC20Metadata(address(tokens[i])).symbol() });
-        }
+        // TODO: Remove the following two lines after deployment.
+        Base_Test.setUp();
+        vm.etch(address(FORK_TOKEN), address(usdc).code);
+
+        // Label the token.
+        vm.label({ account: address(FORK_TOKEN), newLabel: IERC20Metadata(address(FORK_TOKEN)).symbol() });
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -80,26 +63,15 @@ abstract contract Fork_Test is Base_Test {
         }
 
         // Avoid users blacklisted by USDC or USDT.
-        if (token == IERC20(USDC) || token == IERC20(USDT)) {
-            // 4-byte selector for `isBlacklisted(address)`, used by USDC.
-            (bool isSenderBlacklisted,) = address(token).staticcall(abi.encodeWithSelector(0xfe575a87, sender));
-            if (isSenderBlacklisted) {
-                sender = address(uint160(sender) + 1);
-            }
-
-            // 4-byte selector for `isBlackListed(address)`, used by USDT.
-            (bool isRecipientBlacklisted,) = address(token).staticcall(abi.encodeWithSelector(0xe47d6060, recipient));
-            if (isRecipientBlacklisted) {
-                recipient = address(uint160(recipient) + 1);
-            }
-        }
+        assumeNoBlacklisted(address(FORK_TOKEN), sender);
+        assumeNoBlacklisted(address(FORK_TOKEN), recipient);
     }
 
     /// @dev Helper function to deposit on a stream.
     function depositOnStream(uint256 streamId, uint128 depositAmount) internal {
         address sender = flow.getSender(streamId);
         resetPrank({ msgSender: sender });
-        deal({ token: address(token), to: sender, give: depositAmount });
+        deal({ token: address(FORK_TOKEN), to: sender, give: depositAmount });
         safeApprove(depositAmount);
         flow.deposit({
             streamId: streamId,
@@ -111,7 +83,7 @@ abstract contract Fork_Test is Base_Test {
 
     /// @dev Use a low-level call to ignore reverts in case of USDT.
     function safeApprove(uint256 amount) internal {
-        (bool success,) = address(token).call(abi.encodeCall(IERC20.approve, (address(flow), amount)));
+        (bool success,) = address(FORK_TOKEN).call(abi.encodeCall(IERC20.approve, (address(flow), amount)));
         success;
     }
 }

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -31,13 +31,13 @@ abstract contract Fork_Test is Base_Test {
         // TODO: uncomment the following line after deployment.
         // vm.createSelectFork({ blockNumber: 21_718_689, urlOrAlias: "mainnet" });
 
-        // TODO: update the flow contract address once deployed.
+        // TODO: update the flow contract address once deployed and uncomment the following lines.
         // Load mainnet address.
         // flow = ISablierFlow(0x3DF2AAEdE81D2F6b261F79047517713B8E844E04);
         // Label the flow contract.
         // vm.label(address(flow), "Flow");
 
-        // TODO: Remove the following two lines after deployment.
+        // TODO: comment the following two lines after deployment.
         Base_Test.setUp();
         vm.etch(address(FORK_TOKEN), address(usdc).code);
 

--- a/tests/fork/tokens/DAI.t.sol
+++ b/tests/fork/tokens/DAI.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Flow_Fork_Test } from "../Flow.t.sol";
+
+/// @dev A typical 18-decimal ERC-20 token with a normal total supply.
+IERC20 constant DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+
+contract DAI_Flow_Fork_Test is Flow_Fork_Test(DAI) { }

--- a/tests/fork/tokens/EURS.t.sol
+++ b/tests/fork/tokens/EURS.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Flow_Fork_Test } from "../Flow.t.sol";
+
+/// @dev An ERC-20 token with 2 decimals.
+IERC20 constant EURS = IERC20(0xdB25f211AB05b1c97D595516F45794528a807ad8);
+
+contract EURS_Flow_Fork_Test is Flow_Fork_Test(EURS) { }

--- a/tests/fork/tokens/SHIBA.t.sol
+++ b/tests/fork/tokens/SHIBA.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Flow_Fork_Test } from "../Flow.t.sol";
+
+/// @dev An ERC-20 token with a large total supply.
+IERC20 constant SHIBA = IERC20(0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE);
+
+contract SHIBA_Flow_Fork_Test is Flow_Fork_Test(SHIBA) { }

--- a/tests/fork/tokens/USDC.t.sol
+++ b/tests/fork/tokens/USDC.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Flow_Fork_Test } from "../Flow.t.sol";
+
+/// @dev An ERC-20 token with 6 decimals.
+IERC20 constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+
+contract USDC_Flow_Fork_Test is Flow_Fork_Test(USDC) { }

--- a/tests/fork/tokens/USDT.t.sol
+++ b/tests/fork/tokens/USDT.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Flow_Fork_Test } from "../Flow.t.sol";
+
+/// @dev An ERC-20 token that suffers from the missing return value bug.
+IERC20 constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
+
+contract USDT_Flow_Fork_Test is Flow_Fork_Test(USDT) { }


### PR DESCRIPTION
It required some additional changes because for all the tokens, the fork tests were running in a single run. Therefore, in addition to https://github.com/sablier-labs/lockup/issues/1197, this PR also refactors the fork tests to follow the same pattern as Lockup.