### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In-depth documentation is available at [docs.sablier.com](https://docs.sablier.c
 
 Sablier Flow is a debt tracking protocol that tracks tokens owed between two parties, enabling open-ended token
 streaming. A Flow stream is characterized by its rate per second (rps). The relationship between the amount owed and
-time elapsed is linear is be defined as:
+time elapsed is linear and defined as:
 
 ```math
 \text{amount owed} = rps \cdot \text{elapsed time}


### PR DESCRIPTION
Fixed small typo in the README related to owed amount formula reference.