### PR TITLE
ci: bump checkout to v5

### DIFF
--- a/.github/workflows/ci-multibuild.yml
+++ b/.github/workflows/ci-multibuild.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Install Bun"
         uses: "oven-sh/setup-bun@v2"


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0