### PR TITLE
perf(invariant): using bounds to lower discard rates

### DIFF
--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -8,12 +8,11 @@ import { FlowNFTDescriptor } from "src/FlowNFTDescriptor.sol";
 import { ISablierFlow } from "src/interfaces/ISablierFlow.sol";
 import { SablierFlow } from "src/SablierFlow.sol";
 import { Assertions } from "./utils/Assertions.sol";
-import { Constants } from "./utils/Constants.sol";
 import { Modifiers } from "./utils/Modifiers.sol";
 import { Users } from "./utils/Types.sol";
 import { Vars } from "./utils/Vars.sol";
 
-abstract contract Base_Test is Assertions, Constants, Modifiers {
+abstract contract Base_Test is Assertions, Modifiers {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
@@ -86,10 +85,5 @@ abstract contract Base_Test is Assertions, Constants, Modifiers {
                 abi.encode(address(comptroller), address(nftDescriptor))
             )
         );
-    }
-
-    /// @dev Calculates the default deposit amount using `TRANSFER_VALUE` and `decimals`.
-    function getDefaultDepositAmount(uint8 decimals) internal pure returns (uint128 depositAmount) {
-        return uint128(TRANSFER_VALUE * (10 ** decimals));
     }
 }

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -8,11 +8,12 @@ import { FlowNFTDescriptor } from "src/FlowNFTDescriptor.sol";
 import { ISablierFlow } from "src/interfaces/ISablierFlow.sol";
 import { SablierFlow } from "src/SablierFlow.sol";
 import { Assertions } from "./utils/Assertions.sol";
+import { Constants } from "./utils/Constants.sol";
 import { Modifiers } from "./utils/Modifiers.sol";
 import { Users } from "./utils/Types.sol";
 import { Vars } from "./utils/Vars.sol";
 
-abstract contract Base_Test is Assertions, Modifiers {
+abstract contract Base_Test is Assertions, Constants, Modifiers {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
@@ -85,5 +86,10 @@ abstract contract Base_Test is Assertions, Modifiers {
                 abi.encode(address(comptroller), address(nftDescriptor))
             )
         );
+    }
+
+    /// @dev Calculates the default deposit amount using `TRANSFER_VALUE` and `decimals`.
+    function getDefaultDepositAmount(uint8 decimals) internal pure returns (uint128 depositAmount) {
+        return uint128(TRANSFER_VALUE * (10 ** decimals));
     }
 }

--- a/tests/invariant/README.md
+++ b/tests/invariant/README.md
@@ -21,7 +21,7 @@
 1. For any non-voided stream,
    - if rps = 0 $\implies$ Flow.Status $\in$ {PAUSED_SOLVENT, PAUSED_INSOLVENT}
    - the snapshot time should never decrease
-   - total streams = total debt + total withdrawals.
+   - total streamed = total debt + total withdrawn
 
 1. For any pending stream, rps > 0 and td = 0
 

--- a/tests/invariant/handlers/BaseHandler.sol
+++ b/tests/invariant/handlers/BaseHandler.sol
@@ -15,8 +15,8 @@ abstract contract BaseHandler is StdCheats, Utils {
                                      VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Maximum number of streams that can be created during an invariant campaign.
-    uint256 internal constant MAX_STREAM_COUNT = 100;
+    /// @dev Maximum number of streams that can be created.
+    uint256 internal constant MAX_STREAM_COUNT = 10_000;
 
     /// @dev Maps function names and the number of times they have been called by the stream ID.
     mapping(uint256 streamId => mapping(string func => uint256 calls)) public calls;
@@ -41,7 +41,7 @@ abstract contract BaseHandler is StdCheats, Utils {
 
     modifier useFuzzedToken(uint256 tokenIndex) {
         IERC20[] memory tokens = flowStore.getTokens();
-        vm.assume(tokenIndex < tokens.length);
+        tokenIndex = bound(tokenIndex, 0, tokens.length - 1);
         currentToken = tokens[tokenIndex];
         _;
     }
@@ -64,7 +64,7 @@ abstract contract BaseHandler is StdCheats, Utils {
     /// from becoming excessively large.
     /// @param timeJump A fuzzed value for time warps.
     modifier adjustTimestamp(uint256 timeJump) {
-        vm.assume(timeJump < 40 days);
+        timeJump = bound(timeJump, 0, 40 days);
         skip(timeJump);
         _;
     }

--- a/tests/invariant/handlers/BaseHandler.sol
+++ b/tests/invariant/handlers/BaseHandler.sol
@@ -39,27 +39,6 @@ abstract contract BaseHandler is StdCheats, Utils {
                                      MODIFIERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    modifier useFuzzedToken(uint256 tokenIndex) {
-        IERC20[] memory tokens = flowStore.getTokens();
-        tokenIndex = bound(tokenIndex, 0, tokens.length - 1);
-        currentToken = tokens[tokenIndex];
-        _;
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    CONSTRUCTOR
-    //////////////////////////////////////////////////////////////////////////*/
-
-    constructor(FlowStore flowStore_, ISablierFlow flow_) {
-        comptroller = flow_.comptroller();
-        flowStore = flowStore_;
-        flow = flow_;
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                     MODIFIERS
-    //////////////////////////////////////////////////////////////////////////*/
-
     /// @dev Simulates the passage of time. The time jump is kept under 40 days to prevent the streamed amount
     /// from becoming excessively large.
     /// @param timeJump A fuzzed value for time warps.
@@ -76,5 +55,22 @@ abstract contract BaseHandler is StdCheats, Utils {
         }
         totalCalls[functionName]++;
         _;
+    }
+
+    modifier useFuzzedToken(uint256 tokenIndex) {
+        IERC20[] memory tokens = flowStore.getTokens();
+        tokenIndex = bound(tokenIndex, 0, tokens.length - 1);
+        currentToken = tokens[tokenIndex];
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    constructor(FlowStore flowStore_, ISablierFlow flow_) {
+        comptroller = flow_.comptroller();
+        flowStore = flowStore_;
+        flow = flow_;
     }
 }

--- a/tests/invariant/handlers/FlowComptrollerHandler.sol
+++ b/tests/invariant/handlers/FlowComptrollerHandler.sol
@@ -10,10 +10,9 @@ contract FlowComptrollerHandler is BaseHandler {
                                      MODIFIERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Since all comptroller-related functions are rarely called compared to core flow functionalities, we limit
-    /// the number of calls to 10.
+    /// @dev Limit the number of calls to the comptroller functions.
     modifier limitNumberOfCalls(string memory name) {
-        vm.assume(totalCalls[name] < 10);
+        vm.assume(totalCalls[name] < 100);
         _;
     }
 

--- a/tests/invariant/handlers/FlowCreateHandler.sol
+++ b/tests/invariant/handlers/FlowCreateHandler.sol
@@ -78,14 +78,15 @@ contract FlowCreateHandler is BaseHandler {
         _checkParams(params);
 
         vm.assume(flowStore.lastStreamId() < MAX_STREAM_COUNT);
-        vm.assume(params.startTime <= getBlockTimestamp());
+        params.startTime = boundUint40(params.startTime, 1, getBlockTimestamp());
 
-        // Calculate the upper bound, based on the token decimals, for the deposit amount.
-        uint256 upperBound = getDescaledAmount(1_000_000e18, IERC20Metadata(address(currentToken)).decimals());
-        uint256 lowerBound = getDescaledAmount(1e18, IERC20Metadata(address(currentToken)).decimals());
-
-        // Make sure the deposit amount is non-zero and less than values that could cause an overflow.
-        vm.assume(params.depositAmount >= lowerBound && params.depositAmount <= upperBound);
+        // Bound the deposit amount.
+        params.depositAmount = boundDepositAmount({
+            amount: params.depositAmount,
+            lowerBound18D: 1e18,
+            upperBound18D: 1_000_000e18,
+            decimals: IERC20Metadata(address(currentToken)).decimals()
+        });
 
         // Mint enough tokens to the Sender.
         deal({
@@ -121,27 +122,27 @@ contract FlowCreateHandler is BaseHandler {
 
     /// @dev Check the relevant parameters fuzzed for create.
     function _checkParams(CreateParams memory params) private {
-        // The protocol doesn't allow the sender or recipient to be the zero address.
-        vm.assume(params.sender != address(0) && params.recipient != address(0));
-
-        // Prevent the contract itself from playing the role of any user.
-        vm.assume(params.sender != address(this) && params.recipient != address(this));
+        // Make sure the sender and recipient are not the zero address or the contract itself.
+        while (params.sender == address(0) || params.sender == address(this)) {
+            params.sender = vm.randomAddress();
+        }
+        while (params.recipient == address(0) || params.recipient == address(this)) {
+            params.recipient = vm.randomAddress();
+        }
 
         // Change the caller.
         setMsgSender(params.sender);
 
         uint8 decimals = IERC20Metadata(address(currentToken)).decimals();
 
-        // Calculate the minimum value in scaled version that can be withdrawn for this token.
-        uint256 mvt = getScaledAmount(1, decimals);
-
         // For 18 decimal, check the rate per second is within a realistic range.
         if (decimals == 18) {
-            vm.assume(params.ratePerSecond > 0.00001e18 && params.ratePerSecond <= 1e18);
+            params.ratePerSecond = boundUint128(params.ratePerSecond, 0.00001e18, 1e18);
         }
         // For all other decimals, choose the minimum rps such that it takes 100 seconds to stream 1 token.
         else {
-            vm.assume(params.ratePerSecond > mvt / 100 && params.ratePerSecond <= 1e18);
+            uint256 mvt = getScaledAmount({ amount: 1, decimals: decimals });
+            params.ratePerSecond = boundUint128(params.ratePerSecond, uint128(mvt / 100), 1e18);
         }
     }
 }

--- a/tests/invariant/handlers/FlowCreateHandler.sol
+++ b/tests/invariant/handlers/FlowCreateHandler.sol
@@ -123,12 +123,8 @@ contract FlowCreateHandler is BaseHandler {
     /// @dev Check the relevant parameters fuzzed for create.
     function _checkParams(CreateParams memory params) private {
         // Make sure the sender and recipient are not the zero address or the contract itself.
-        while (params.sender == address(0) || params.sender == address(this)) {
-            params.sender = vm.randomAddress();
-        }
-        while (params.recipient == address(0) || params.recipient == address(this)) {
-            params.recipient = vm.randomAddress();
-        }
+        params.sender = fuzzAddrWithExclusion(params.sender, address(this));
+        params.recipient = fuzzAddrWithExclusion(params.recipient, address(this));
 
         // Change the caller.
         setMsgSender(params.sender);

--- a/tests/invariant/handlers/FlowHandler.sol
+++ b/tests/invariant/handlers/FlowHandler.sol
@@ -7,11 +7,10 @@ import { UD21x18, UNIT } from "@prb/math/src/UD21x18.sol";
 
 import { ISablierFlow } from "src/interfaces/ISablierFlow.sol";
 
-import { Constants } from "../../utils/Constants.sol";
 import { FlowStore } from "../stores/FlowStore.sol";
 import { BaseHandler } from "./BaseHandler.sol";
 
-contract FlowHandler is BaseHandler, Constants {
+contract FlowHandler is BaseHandler {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
@@ -313,9 +312,7 @@ contract FlowHandler is BaseHandler, Constants {
         instrument(currentStreamId, "withdraw")
     {
         // The protocol doesn't allow the withdrawal address to be the zero address.
-        while (to == address(0) || to == address(flow)) {
-            to = vm.randomAddress();
-        }
+        to = fuzzAddrWithExclusion(to, address(flow));
 
         // Check if there is anything to withdraw.
         vm.assume(flow.coveredDebtOf(currentStreamId) > 0);

--- a/tests/invariant/handlers/FlowHandler.sol
+++ b/tests/invariant/handlers/FlowHandler.sol
@@ -3,14 +3,15 @@ pragma solidity >=0.8.22;
 
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { UD21x18 } from "@prb/math/src/UD21x18.sol";
+import { UD21x18, UNIT } from "@prb/math/src/UD21x18.sol";
 
 import { ISablierFlow } from "src/interfaces/ISablierFlow.sol";
 
+import { Constants } from "../../utils/Constants.sol";
 import { FlowStore } from "../stores/FlowStore.sol";
 import { BaseHandler } from "./BaseHandler.sol";
 
-contract FlowHandler is BaseHandler {
+contract FlowHandler is BaseHandler, Constants {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
@@ -49,7 +50,7 @@ contract FlowHandler is BaseHandler {
         if (lastStreamId == 0) {
             return;
         }
-        vm.assume(streamIndex < lastStreamId);
+        streamIndex = bound(streamIndex, 0, lastStreamId - 1);
         currentStreamId = flowStore.streamIds(streamIndex);
         _;
     }
@@ -75,7 +76,7 @@ contract FlowHandler is BaseHandler {
 
     /// @dev Function to increase the flow contract balance for the fuzzed token.
     function randomTransfer(uint256 tokenIndex, uint256 amount) external useFuzzedToken(tokenIndex) {
-        vm.assume(amount > 0 && amount < 100e18);
+        amount = bound(amount, 1, 100e18);
         amount *= 10 ** IERC20Metadata(address(currentToken)).decimals();
 
         deal({ token: address(currentToken), to: address(flow), give: currentToken.balanceOf(address(flow)) + amount });
@@ -104,24 +105,33 @@ contract FlowHandler is BaseHandler {
 
         uint8 decimals = flow.getTokenDecimals(currentStreamId);
 
-        // The rate per second must be greater than zero and different from the current rate per second.
-        vm.assume(newRatePerSecond.unwrap() > 0 && newRatePerSecond.unwrap() != currentRatePerSecond);
-
         // Calculate the minimum value in scaled version that can be withdrawn for this token.
         uint256 mvt = getScaledAmount(1, decimals);
 
         // Check the rate per second is within a realistic range such that it can also be smaller than mvt.
         if (decimals == 18) {
-            vm.assume(newRatePerSecond.unwrap() > 0.00001e18 && newRatePerSecond.unwrap() <= 1e18);
+            newRatePerSecond = boundRatePerSecond({
+                ratePerSecond: newRatePerSecond,
+                minRatePerSecond: UD21x18.wrap(0.00001e18),
+                maxRatePerSecond: UNIT
+            });
         } else {
-            vm.assume(newRatePerSecond.unwrap() > mvt / 100 && newRatePerSecond.unwrap() <= 1e18);
+            newRatePerSecond = boundRatePerSecond({
+                ratePerSecond: newRatePerSecond,
+                minRatePerSecond: UD21x18.wrap(uint128(mvt / 100)),
+                maxRatePerSecond: UNIT
+            });
+        }
+
+        // The rate per second must be different from the current rate per second.
+        if (newRatePerSecond.unwrap() == currentRatePerSecond) {
+            newRatePerSecond = UD21x18.wrap(currentRatePerSecond + 1);
         }
 
         // Adjust the rate per second.
         flow.adjustRatePerSecond(currentStreamId, newRatePerSecond);
 
         flowStore.pushPeriod({
-            typeOfPeriod: "adjustRatePerSecond",
             streamId: currentStreamId,
             newRatePerSecond: newRatePerSecond.unwrap(),
             blockTimestamp: getBlockTimestamp()
@@ -143,12 +153,13 @@ contract FlowHandler is BaseHandler {
         // Voided streams cannot be deposited on.
         vm.assume(!flow.isVoided(currentStreamId));
 
-        // Calculate the upper bound, based on the token decimals, for the deposit amount.
-        uint256 upperBound = getDescaledAmount(1_000_000e18, flow.getTokenDecimals(currentStreamId));
-        uint256 lowerBound = getDescaledAmount(1e18, flow.getTokenDecimals(currentStreamId));
-
-        // Make sure the deposit amount is non-zero and less than values that could cause an overflow.
-        vm.assume(depositAmount >= lowerBound && depositAmount <= upperBound);
+        // Bound the deposit amount.
+        depositAmount = boundDepositAmount({
+            amount: depositAmount,
+            lowerBound18D: 1e18,
+            upperBound18D: 1_000_000e18,
+            decimals: flow.getTokenDecimals(currentStreamId)
+        });
 
         IERC20 token = flow.getToken(currentStreamId);
 
@@ -190,12 +201,7 @@ contract FlowHandler is BaseHandler {
         // Pause the stream.
         flow.pause(currentStreamId);
 
-        flowStore.pushPeriod({
-            typeOfPeriod: "pause",
-            streamId: currentStreamId,
-            newRatePerSecond: 0,
-            blockTimestamp: getBlockTimestamp()
-        });
+        flowStore.pushPeriod({ streamId: currentStreamId, newRatePerSecond: 0, blockTimestamp: getBlockTimestamp() });
     }
 
     function refund(
@@ -210,13 +216,13 @@ contract FlowHandler is BaseHandler {
         updateFlowHandlerStates
         instrument(currentStreamId, "refund")
     {
-        uint256 refundableAmount = flow.refundableAmountOf(currentStreamId);
+        uint128 refundableAmount = flow.refundableAmountOf(currentStreamId);
 
         // The protocol doesn't allow zero refund amounts.
         vm.assume(refundableAmount > 0);
 
         // Make sure the refund amount is non-zero and it is less or equal to the maximum refundable amount.
-        vm.assume(refundAmount >= 1 && refundAmount <= refundableAmount);
+        refundAmount = boundUint128(refundAmount, 1, refundableAmount);
 
         // Refund from stream.
         flow.refund(currentStreamId, refundAmount);
@@ -250,16 +256,23 @@ contract FlowHandler is BaseHandler {
 
         // Check the rate per second is within a realistic range such that it can also be smaller than mvt.
         if (decimals == 18) {
-            vm.assume(ratePerSecond.unwrap() > 0.00001e18 && ratePerSecond.unwrap() <= 1e18);
+            ratePerSecond = boundRatePerSecond({
+                ratePerSecond: ratePerSecond,
+                minRatePerSecond: UD21x18.wrap(0.00001e18),
+                maxRatePerSecond: UNIT
+            });
         } else {
-            vm.assume(ratePerSecond.unwrap() > mvt / 100 && ratePerSecond.unwrap() <= 1e18);
+            ratePerSecond = boundRatePerSecond({
+                ratePerSecond: ratePerSecond,
+                minRatePerSecond: UD21x18.wrap(uint128(mvt / 100)),
+                maxRatePerSecond: UNIT
+            });
         }
 
         // Restart the stream.
         flow.restart(currentStreamId, ratePerSecond);
 
         flowStore.pushPeriod({
-            typeOfPeriod: "restart",
             streamId: currentStreamId,
             newRatePerSecond: ratePerSecond.unwrap(),
             blockTimestamp: getBlockTimestamp()
@@ -283,12 +296,7 @@ contract FlowHandler is BaseHandler {
         // Void the stream.
         flow.void(currentStreamId);
 
-        flowStore.pushPeriod({
-            typeOfPeriod: "void",
-            streamId: currentStreamId,
-            newRatePerSecond: 0,
-            blockTimestamp: getBlockTimestamp()
-        });
+        flowStore.pushPeriod({ streamId: currentStreamId, newRatePerSecond: 0, blockTimestamp: getBlockTimestamp() });
     }
 
     function withdraw(
@@ -305,13 +313,15 @@ contract FlowHandler is BaseHandler {
         instrument(currentStreamId, "withdraw")
     {
         // The protocol doesn't allow the withdrawal address to be the zero address.
-        vm.assume(to != address(0) && to != address(flow));
+        while (to == address(0) || to == address(flow)) {
+            to = vm.randomAddress();
+        }
 
         // Check if there is anything to withdraw.
         vm.assume(flow.coveredDebtOf(currentStreamId) > 0);
 
         // Make sure the withdraw amount is non-zero and it is less or equal to the maximum withdrawable amount.
-        vm.assume(amount >= 1 && amount <= flow.withdrawableAmountOf(currentStreamId));
+        amount = boundUint128(amount, 1, flow.withdrawableAmountOf(currentStreamId));
 
         // There is an edge case when the sender is the same as the recipient. In this scenario, the withdrawal
         // address must be set to the recipient.
@@ -322,7 +332,7 @@ contract FlowHandler is BaseHandler {
         // Withdraw from the stream.
         flow.withdraw{ value: MIN_FEE_WEI }({ streamId: currentStreamId, to: to, amount: amount });
 
-        // Update the withdrawal totals.
-        flowStore.updateTotalWithdrawals(currentStreamId, flow.getToken(currentStreamId), amount);
+        // Update the total withdrawn by stream.
+        flowStore.updateTotalWithdrawn(currentStreamId, flow.getToken(currentStreamId), amount);
     }
 }

--- a/tests/utils/Constants.sol
+++ b/tests/utils/Constants.sol
@@ -2,8 +2,9 @@
 pragma solidity >=0.8.22;
 
 import { UD21x18 } from "@prb/math/src/UD21x18.sol";
+import { BaseConstants } from "@sablier/evm-utils/src/tests/BaseConstants.sol";
 
-abstract contract Constants {
+abstract contract Constants is BaseConstants {
     // Amounts
     uint128 internal constant DEPOSIT_AMOUNT_18D = 50_000e18;
     uint128 internal constant DEPOSIT_AMOUNT_6D = 50_000e6;

--- a/tests/utils/Utils.sol
+++ b/tests/utils/Utils.sol
@@ -3,12 +3,11 @@ pragma solidity >=0.8.22;
 
 import { UD21x18 } from "@prb/math/src/UD21x18.sol";
 import { PRBMathUtils } from "@prb/math/test/utils/Utils.sol";
+import { BaseConstants } from "@sablier/evm-utils/src/tests/BaseConstants.sol";
 import { BaseUtils } from "@sablier/evm-utils/src/tests/BaseUtils.sol";
-
 import { SafeCastLib } from "solady/src/utils/SafeCastLib.sol";
-import { Constants } from "./Constants.sol";
 
-abstract contract Utils is BaseUtils, Constants, PRBMathUtils {
+abstract contract Utils is BaseConstants, BaseUtils, PRBMathUtils {
     using SafeCastLib for uint256;
 
     /// @dev Bound deposit amount to avoid overflow.
@@ -21,27 +20,51 @@ abstract contract Utils is BaseUtils, Constants, PRBMathUtils {
         pure
         returns (uint128 depositAmount)
     {
-        uint128 maxDepositAmount = (type(uint128).max - balance);
-        if (decimals < 18) {
-            maxDepositAmount = maxDepositAmount / uint128(10 ** (18 - decimals));
-        }
+        uint256 maxDepositAmount = getDescaledAmount({ amount: MAX_UINT128 - balance, decimals: decimals });
+        depositAmount = boundUint128(amount, 1, uint128(maxDepositAmount - 1));
+    }
 
-        depositAmount = uint128(_bound(amount, 1, maxDepositAmount - 1));
+    /// @dev Bound deposit amount within lower and upper bounds.
+    function boundDepositAmount(
+        uint128 amount,
+        uint128 lowerBound18D,
+        uint128 upperBound18D,
+        uint8 decimals
+    )
+        internal
+        pure
+        returns (uint128 depositAmount)
+    {
+        uint256 lowerBound = getDescaledAmount({ amount: lowerBound18D, decimals: decimals });
+        uint256 upperBound = getDescaledAmount({ amount: upperBound18D, decimals: decimals });
+        depositAmount = boundUint128(amount, uint128(lowerBound), uint128(upperBound));
     }
 
     /// @dev Bounds the rate per second between a realistic range i.e. for USDC [$50/month $5000/month].
     function boundRatePerSecond(UD21x18 ratePerSecond) internal pure returns (UD21x18) {
-        return bound(ratePerSecond, 0.00002e18, 0.002e18);
+        return boundRatePerSecond({
+            ratePerSecond: ratePerSecond,
+            minRatePerSecond: UD21x18.wrap(0.00002e18),
+            maxRatePerSecond: UD21x18.wrap(0.002e18)
+        });
     }
 
-    /// @dev Calculates the default deposit amount using `TRANSFER_VALUE` and `decimals`.
-    function getDefaultDepositAmount(uint8 decimals) internal pure returns (uint128 depositAmount) {
-        return TRANSFER_VALUE * (10 ** decimals).toUint128();
+    /// @dev Bounds the rate per second between given min and max values.
+    function boundRatePerSecond(
+        UD21x18 ratePerSecond,
+        UD21x18 minRatePerSecond,
+        UD21x18 maxRatePerSecond
+    )
+        internal
+        pure
+        returns (UD21x18)
+    {
+        return bound(ratePerSecond, minRatePerSecond, maxRatePerSecond);
     }
 
     /// @dev Descales the amount to denote it in token's decimals.
     function getDescaledAmount(uint256 amount, uint8 decimals) internal pure returns (uint256) {
-        if (decimals == 18) {
+        if (decimals >= 18) {
             return amount;
         }
 
@@ -51,7 +74,7 @@ abstract contract Utils is BaseUtils, Constants, PRBMathUtils {
 
     /// @dev Scales the amount to denote it in 18 decimals.
     function getScaledAmount(uint256 amount, uint8 decimals) internal pure returns (uint256) {
-        if (decimals == 18) {
+        if (decimals >= 18) {
             return amount;
         }
 

--- a/tests/utils/Utils.sol
+++ b/tests/utils/Utils.sol
@@ -3,11 +3,11 @@ pragma solidity >=0.8.22;
 
 import { UD21x18 } from "@prb/math/src/UD21x18.sol";
 import { PRBMathUtils } from "@prb/math/test/utils/Utils.sol";
-import { BaseConstants } from "@sablier/evm-utils/src/tests/BaseConstants.sol";
 import { BaseUtils } from "@sablier/evm-utils/src/tests/BaseUtils.sol";
 import { SafeCastLib } from "solady/src/utils/SafeCastLib.sol";
+import { Constants } from "./Constants.sol";
 
-abstract contract Utils is BaseConstants, BaseUtils, PRBMathUtils {
+abstract contract Utils is Constants, BaseUtils, PRBMathUtils {
     using SafeCastLib for uint256;
 
     /// @dev Bound deposit amount to avoid overflow.
@@ -60,6 +60,20 @@ abstract contract Utils is BaseConstants, BaseUtils, PRBMathUtils {
         returns (UD21x18)
     {
         return bound(ratePerSecond, minRatePerSecond, maxRatePerSecond);
+    }
+
+    /// @dev Fuzz an address by excluding the zero address and the address provided.
+    function fuzzAddrWithExclusion(address addr, address toExclude) internal view returns (address) {
+        while (addr == address(0) || addr == toExclude) {
+            addr = vm.randomAddress();
+        }
+
+        return addr;
+    }
+
+    /// @dev Calculates the default deposit amount using `TRANSFER_VALUE` and `decimals`.
+    function getDefaultDepositAmount(uint8 decimals) internal pure returns (uint128 depositAmount) {
+        return uint128(TRANSFER_VALUE * (10 ** decimals));
     }
 
     /// @dev Descales the amount to denote it in token's decimals.


### PR DESCRIPTION
Closes https://github.com/sablier-labs/flow/issues/463

1. While working on this, I discovered a bug in the implementation of `calculateExpectedTotalStreamed` which is also fixed in this PR.
2. Renamed `totalWithdrawalsByStream` to `totalWithdrawnByStream` as the former mean "total number of withdrawals".
3. Increased `MAX_STREAM_COUNT` to 10,000 and other limiting variables for better invariant results.
4. Removed redundant `funcName` from `Period` struct.

| Before | After |
| --- |--- |
| https://app.warp.dev/block/iME6toa8g3KJTEt8AuuBLj | https://app.warp.dev/block/lJxqn3ztjFQWASmKJTl9On | 

In some cases such as `refund`, the discard rate is still very high because I am using `vm.assume(refundableAmount > 0);`. IMO this is acceptable. The rule that I followed is:

1. Use `bounds` on fuzzed inputs.
5. Use `vm.assume` when specific conditions on streams, such as in case of refund, are required. Using bound here would mean changing states of streams deliberately within the handlers which should be avoided.