### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci-multibuild.yml
+++ b/.github/workflows/ci-multibuild.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v6"
 
       - name: "Install Bun"
         uses: "oven-sh/setup-bun@v2"


### PR DESCRIPTION
Routine update of checkout action to the latest stable version (v6).

https://github.com/actions/checkout/releases/tag/v6.0.0